### PR TITLE
Fix card title svg margin right

### DIFF
--- a/src/styles/card/index.css
+++ b/src/styles/card/index.css
@@ -30,7 +30,7 @@
   justify-content: center;
 }
 
-.title svg {
+.title > h2 > svg {
   margin-right: var(--card-title-icon-margin);
 }
 


### PR DESCRIPTION
Fix the margin right which was applied to all svg elements in to the card title, now only the svgs which are inside h2 tag got this margin 