### PR TITLE
grid: fix col to have correct flex-direction

### DIFF
--- a/src/styles/grid/index.css
+++ b/src/styles/grid/index.css
@@ -20,6 +20,7 @@
 }
 
 .grid {
+  width: 100%;
   flex-direction: row;
   align-content: stretch;
 }

--- a/src/styles/grid/index.css
+++ b/src/styles/grid/index.css
@@ -15,9 +15,17 @@
   align-items: stretch;
 }
 
+.stretch > .col > * {
+  flex: 1;
+}
+
 .grid {
   flex-direction: row;
   align-content: stretch;
+}
+
+.col {
+  flex-direction: column;
 }
 
 .row {


### PR DESCRIPTION
This fixes a small issue which could have a great impact on layouts
depending on `Grid` component.

We missed the `flex-direction: column` in `Col` styles, causing any `div`
placed as children of `Col` to be rendered in "column" direction
(effectively rendering as `div`s had `display: inline`)/