### PR TITLE
spacing: add display inline-flex

### DIFF
--- a/src/styles/spacing/index.css
+++ b/src/styles/spacing/index.css
@@ -1,6 +1,7 @@
 @import "../spacing.css";
 
 .spacing {
+  display: inline-flex;
   margin: 0;
 
   & + * {


### PR DESCRIPTION
### Context 

`Spacing` is breaking line 
![spacing](https://user-images.githubusercontent.com/479495/41979389-604c29c6-79fa-11e8-9982-ed4a15edf500.png)

This PR adds `display: inline-flex` to fix line breakings