### PR TITLE
popover: remove padding and uppercase text

### DIFF
--- a/src/styles/popover/index.css
+++ b/src/styles/popover/index.css
@@ -33,7 +33,6 @@
   border-radius: var(--popover-link-border-radius-top);
   border: var(--popover-border);
   border-bottom: none;
-  padding: var(--popover-link-padding);
 
   & > * {
     display: block;
@@ -49,7 +48,7 @@
   outline: none;
   padding: var(--popover-link-padding);
   text-align: left;
-  text-transform: uppercase;
+  white-space: nowrap;
   width: 100%;
 }
 

--- a/src/styles/popover/index.css
+++ b/src/styles/popover/index.css
@@ -14,6 +14,10 @@
   z-index: var(--popover-z-index);
 }
 
+.content {
+  padding: var(--popover-content-padding);
+}
+
 .menu {
   display: block;
 }

--- a/src/styles/popover/properties.css
+++ b/src/styles/popover/properties.css
@@ -52,6 +52,7 @@
   --popover-bottom-start-top: calc(100% + var(--spacing-small));
   --popover-color-dark: var(--color-light-carbon-100);
   --popover-color: var(--color-white);
+  --popover-content-padding: var(--spacing-small);
   --popover-left-end-bottom: calc(var(--spacing-tiny) * -1);
   --popover-left-middle-top: 50%;
   --popover-left-middle-transform: translateY(-50%);


### PR DESCRIPTION
This PR refactor Popover component

- Remove padding from `children`
- Remove text-transform uppercase from links on PopoverMenu
- Resolves https://github.com/pagarme/pilot/issues/762