### PR TITLE
sidebar: refactor style

### DIFF
--- a/src/styles/sidebar/index.css
+++ b/src/styles/sidebar/index.css
@@ -16,9 +16,18 @@
   display: block;
   font-family: var(--sidebar-font-family);
   min-height: 100vh;
-  flex: 0 0 var(--sidebar-width);
-  width: var(--sidebar-width);
   user-select: var(--sidebar-user-select);
+  width: var(--sidebar-width);
+
+  & > div {
+    display: flex;
+    flex: 1;
+    width: 100%;
+  }
+}
+
+.sidebar nav {
+  flex: 1;
 }
 
 .menu,
@@ -29,7 +38,6 @@
 }
 
 .collapsed {
-  flex: 0 0 var(--sidebar-collapsed-width);
   width: var(--sidebar-collapsed-width);
 
   & header {
@@ -39,31 +47,5 @@
   & header svg {
     height: var(--sidebar-collapsed-header-button-size);
     width: var(--sidebar-collapsed-header-button-size);
-  }
-}
-
-@media (--media-desk) {
-
-  .sidebar {
-    width: var(--sidebar-width-desk);
-    flex: 0 0 var(--sidebar-width-desk);
-  }
-
-  .collapsed {
-    width: var(--sidebar-collapsed-width-desk);
-    flex: 0 0 var(--sidebar-collapsed-width-desk);
-  }
-}
-
-@media (--media-tv) {
-
-  .sidebar {
-    width: var(--sidebar-width-tv);
-    flex: 0 0 var(--sidebar-width-tv);
-  }
-
-  .collapsed {
-    width: var(--sidebar-collapsed-width-tv);
-    flex: 0 0 var(--sidebar-collapsed-width-tv);
   }
 }

--- a/src/styles/sidebar/properties.css
+++ b/src/styles/sidebar/properties.css
@@ -2,13 +2,9 @@
 @import "../media.css";
 
 :root {
-  --sidebar-width: 192px;
-  --sidebar-width-desk: 222px;
-  --sidebar-width-tv: 320px;
+  --sidebar-width: 222px;
 
-  --sidebar-collapsed-width: 72px;
-  --sidebar-collapsed-width-desk: 78px;
-  --sidebar-collapsed-width-tv: 116px;
+  --sidebar-collapsed-width: 78px;
 
   --sidebar-background-color: var(--color-light-carbon-40);
 
@@ -20,12 +16,13 @@
   --sidebar-header-border-bottom: 1px solid var(--color-light-steel-200);
 
   --sidebar-header-button-border: none;
+  --sidebar-header-button-focus-border: 1px solid var(--color-light-greenish-100);
   --sidebar-header-button-background: none;
   --sidebar-header-button-color: var(--color-white);
   --sidebar-header-button-padding: 0;
   --sidebar-collapsed-header-button-size: var(--spacing-medium);
 
-  --sidebar-content-padding: var(--spacing-medium) 0;
+  --sidebar-content-padding: var(--spacing-medium);
 
   --sidebar-link-color: var(--color-white);
   --sidebar-link-border-color: transparent;
@@ -41,9 +38,17 @@
   --sidebar-link-enter-border-color: var(--color-light-greenish-100);
 
   --sidebar-link-active-color: var(--color-light-greenish-100);
+  --sidebar-link-active-border-color: var(--color-light-steel-200);
 
-  --sidebar-sublink-padding: 0 var(--spacing-medium) var(--spacing-medium);
-  --sidebar-sublink-button-padding-left: var(--spacing-large);
+  --sidebar-sublink-padding:
+    0
+    var(--spacing-medium)
+    var(--spacing-medium);
+  --sidebar-sublink-button-padding:
+    0
+    0
+    0
+    var(--spacing-large);
   --sidebar-sublink-active-color: var(--color-light-greenish-100);
   --sidebar-sublink-before-background-color: var(--color-light-greenish-100);
   --sidebar-sublink-before-left: 6px;
@@ -51,11 +56,9 @@
 
   --sidebar-title-color: var(--color-white);
   --sidebar-title-font-size: 14px;
-  --sidebar-title-font-size-desk: 14px;
-  --sidebar-title-font-size-tv: 16px;
   --sidebar-title-line-height: 14px;
   --sidebar-title-margin: 0;
-  --sidebar-title-text-transform: uppercase;
+  --sidebar-title-text-transform: none;
 
   --sidebar-user-select: none;
 }

--- a/src/styles/sidebar/sidebar-header.css
+++ b/src/styles/sidebar/sidebar-header.css
@@ -25,4 +25,9 @@
   cursor: pointer;
   outline: none;
   padding: var(--sidebar-header-button-padding);
+
+  &:focus {
+    border: var(--sidebar-header-button-focus-border);
+    border-radius: 0;
+  }
 }

--- a/src/styles/sidebar/sidebar-link.css
+++ b/src/styles/sidebar/sidebar-link.css
@@ -7,30 +7,44 @@
   border-style: var(--sidebar-link-border-style);
   border-width: var(--sidebar-link-border-width);
   cursor: pointer;
+  display: flex;
+  flex-direction: column;
   list-style: none;
   padding: 0;
 
-  & > button {
+  & > * {
+    flex: 1;
+  }
+
+  & button {
     padding: var(--sidebar-link-padding);
   }
 
   /* active and open */
 
-  &.active.open > button .title { /* stylelint-disable-line selector-max-class */
+  &.active.open .title { /* stylelint-disable-line selector-max-class */
     color: var(--sidebar-title-color);
+  }
+
+  &.open .submenu .active .title { /* stylelint-disable-line selector-max-class */
+    color: var(--sidebar-sublink-active-color);
   }
 
   /* active */
 
-  &.active > button .title { /* stylelint-disable-line selector-max-class */
+  &.active {
+    background-color: var(--sidebar-link-enter-background-color);
+    border-color: var(--sidebar-link-active-border-color);
+  }
+
+  &.active .title { /* stylelint-disable-line selector-max-class */
     color: var(--sidebar-link-active-color);
   }
 
   /* focus, hover and open */
 
   &.focused,
-  &:hover,
-  &.open {
+  &:hover {
     background-color: var(--sidebar-link-enter-background-color);
     border-color: var(--sidebar-link-enter-border-color);
   }
@@ -40,15 +54,15 @@
   list-style: none;
   padding: var(--sidebar-sublink-padding);
 
-  & > button {
-    padding-left: var(--sidebar-sublink-button-padding-left);
+  & button {
+    padding: var(--sidebar-sublink-button-padding);
     position: relative;
   }
 
   /* focus and hover */
 
-  & > button:focus:before,
-  &:hover > button:before {
+  & button:focus:before,
+  &:hover button:before {
     background-color: var(--sidebar-sublink-before-background-color);
     content: "";
     height: 100%;
@@ -57,15 +71,9 @@
     top: 0;
     width: var(--sidebar-sublink-before-width);
   }
-
-  /* active */
-
-  &.active .title { /* stylelint-disable-line selector-max-class */
-    color: var(--sidebar-sublink-active-color);
-  }
 }
 
-.link > button {
+.link button {
   appearance: none;
   background: none;
   border: none;
@@ -109,19 +117,5 @@
 
   & svg {
     margin: 0;
-  }
-}
-
-@media (--media-desk) {
-
-  .title {
-    font-size: var(--sidebar-title-font-size-desk);
-  }
-}
-
-@media (--media-tv) {
-
-  .title {
-    font-size: var(--sidebar-title-font-size-tv);
   }
 }


### PR DESCRIPTION
- Remove `tv` media-query
- Change `titles` transform
- Add flex to the `nav`
- Refactor `titles` selectors
- Refactor menu icon to `Button` with icon
- Refactor `SidebarContent` padding
- Resolves https://github.com/pagarme/pilot/issues/751 & https://github.com/pagarme/pilot/issues/752
- It links with https://github.com/pagarme/former-kit/pull/157