### PR TITLE
popover: refactor styles

### DIFF
--- a/src/styles/popover/index.css
+++ b/src/styles/popover/index.css
@@ -6,9 +6,17 @@
   position: relative;
 }
 
+.popover,
+.popover * {
+  box-sizing: border-box;
+}
+
 .popover {
   background-color: var(--popover-color);
+  border-color: var(--popover-border-color);
   border-radius: var(--popover-border-radius);
+  border-style: var(--popover-border-style);
+  border-width: var(--popover-border-width);
   display: block;
   position: absolute;
   z-index: var(--popover-z-index);
@@ -16,6 +24,10 @@
 
 .content {
   padding: var(--popover-content-padding);
+
+  & > * {
+    display: block;
+  }
 }
 
 .menu {
@@ -23,8 +35,11 @@
 }
 
 .popover:before {
-  background-color: var(--popover-color);
-  border: var(--popover-border);
+  background-color: inherit;
+  border-color: inherit;
+  border-radius: inherit;
+  border-style: inherit;
+  border-width: inherit;
   content: "";
   display: block;
   height: var(--popover-arrow-size);
@@ -33,19 +48,21 @@
   width: var(--popover-arrow-size);
 }
 
-.popover > :first-child {
-  border-radius: var(--popover-link-border-radius-top);
-  border: var(--popover-border);
-  border-bottom: none;
+.popover > *:not(.menu) {
+  border-color: var(--popover-child-border-color);
+  border-style: var(--popover-child-border-style);
+  border-width: var(--popover-child-border-width);
+}
 
-  & > * {
-    display: block;
-  }
+.popover > :first-child {
+  border-color: transparent;
 }
 
 .link {
   background-color: initial;
-  border: var(--popover-border);
+  border-color: var(--popover-child-border-color);
+  border-style: var(--popover-child-border-style);
+  border-width: var(--popover-child-border-width);
   color: var(--popover-link-text-color);
   cursor: pointer;
   display: block;
@@ -54,41 +71,31 @@
   text-align: left;
   white-space: nowrap;
   width: 100%;
+
+  &:last-of-type {
+    border-radius: var(--popover-link-border-radius-bottom);
+  }
 }
 
-.link:not(:last-of-type) {
-  border-bottom: none;
-}
-
-.link:last-of-type {
-  border-radius: var(--popover-link-border-radius-bottom);
-}
+/* hover */
 
 .link:hover {
   background-color: var(--popover-link-hover-background);
-  border-top-color: var(--popover-link-hover-border-color);
-
-  & + .link {
-    border-top-color: var(--popover-link-hover-border-color);
-  }
 }
+
+/* focus */
+
+.link:focus {
+  outline: 1px solid #000000;
+}
+
+/* active */
 
 .link:active {
   background-color: var(--popover-link-active-background);
-  border-color: var(--popover-link-active-border-color);
-
-  & + .link {
-    border-color: var(--popover-link-active-border-color);
-  }
 }
 
-.link:focus:not(:active) {
-  border-color: var(--popover-link-focus-border-color);
-
-  & + .link {
-    border-top-color: var(--popover-link-focus-border-color);
-  }
-}
+/* placements */
 
 .popover[class*="bottom"] {
   top: var(--popover-bottom-start-top);
@@ -239,29 +246,30 @@
   }
 }
 
-.dark {
+/* dark theme */
 
-  &.popover {
-    background-color: var(--popover-color-dark);
+.dark.popover {
+  border: none;
+  background-color: var(--popover-color-dark);
+
+  &:before {
+    background: var(--popover-color-dark);
+    border-color: var(--popover-border-color-dark);
   }
 
-  &.popover:before {
-    background-color: var(--popover-color-dark);
-    border: var(--popover-border-dark);
+  & > * {
+    border-color: var(--popover-child-border-color-dark);
+    border-style: var(--popover-child-border-style-dark);
+    border-width: var(--popover-child-border-width-dark);
   }
 
-  &.popover * {
-    border: none;
-  }
-
-  &.popover > :first-child {
-    border-bottom: var(--popover-border-first);
+  & > :first-child {
+    border-width: 0;
     color: var(--popover-link-text-color-dark);
   }
 
-  &.popover .link {
-    background-color: var(--popover-color-dark);
-    border: var(--popover-border-dark);
+  & .link {
+    border-width: 0;
     color: var(--popover-link-text-color-dark);
 
     &:hover {

--- a/src/styles/popover/properties.css
+++ b/src/styles/popover/properties.css
@@ -3,10 +3,26 @@
 @import "../z-index.css";
 
 :root {
+  --popover-border-color: var(--color-light-grey-50);
+  --popover-border-radius: 3px;
+  --popover-border-style: solid;
+  --popover-border-width: 1px;
+  --popover-child-border-color: var(--color-light-grey-50);
+  --popover-child-border-style: solid;
+  --popover-child-border-width:
+    1px
+    0
+    0;
+  --popover-color: var(--color-white);
+
   --popover-arrow-bottom-center-left: calc(50% - var(--spacing-tiny));
-  --popover-arrow-bottom-radius: var(--popover-border-radius) 0 0 0;
+  --popover-arrow-bottom-radius:
+    var(--popover-border-radius)
+    0
+    0
+    0;
   --popover-arrow-bottom-start-left: var(--spacing-small);
-  --popover-arrow-bottom-start-top: calc(var(--spacing-tiny) * -1);
+  --popover-arrow-bottom-start-top: -9px;
   --popover-arrow-left-background:
     linear-gradient(
       225deg,
@@ -15,8 +31,12 @@
     );
   --popover-arrow-left-end-bottom: var(--spacing-small);
   --popover-arrow-left-middle-top: calc(50% - var(--spacing-tiny));
-  --popover-arrow-left-radius: 0 var(--popover-border-radius) 0 0;
-  --popover-arrow-left-right: calc(var(--spacing-tiny) * -1);
+  --popover-arrow-left-radius:
+    0
+    var(--popover-border-radius)
+    0
+    0;
+  --popover-arrow-left-right: -9px;
   --popover-arrow-left-start-top: var(--spacing-small);
   --popover-arrow-right-background:
     linear-gradient(
@@ -25,9 +45,13 @@
       rgba(0, 0, 0, 0) 50%
     );
   --popover-arrow-right-end-bottom: var(--spacing-small);
-  --popover-arrow-right-left: calc(var(--spacing-tiny) * -1);
+  --popover-arrow-right-left: -9px;
   --popover-arrow-right-middle-top: calc(50% - var(--spacing-tiny));
-  --popover-arrow-right-radius: 0 0 0 var(--popover-border-radius);
+  --popover-arrow-right-radius:
+    0
+    0
+    0
+    var(--popover-border-radius);
   --popover-arrow-right-start-top: var(--spacing-small);
   --popover-arrow-size: var(--spacing-small);
   --popover-arrow-top-background:
@@ -36,28 +60,17 @@
       var(--popover-color) 50%,
       rgba(0, 0, 0, 0) 50%
     );
-  --popover-arrow-top-bottom: calc(var(--spacing-tiny) * -1);
+  --popover-arrow-top-bottom: -9px;
   --popover-arrow-top-center-left: calc(50% - var(--spacing-tiny));
   --popover-arrow-top-end-right: var(--spacing-small);
-  --popover-arrow-top-radius: 0 0 var(--popover-border-radius) 0;
+  --popover-arrow-top-radius:
+    0
+    0
+    var(--popover-border-radius) 0;
   --popover-arrow-top-start-left: var(--spacing-small);
-  --popover-border-dark: var(--color-light-carbon-100);
-  --popover-border-first: 1px dashed var(--color-light-steel-200);
-  --popover-border-radius: 3px;
-  --popover-border: 1px solid var(--color-light-grey-50);
-  --popover-bottom-center-left: 50%;
-  --popover-bottom-center-transform: translateX(-50%);
-  --popover-bottom-end-right: calc(var(--spacing-small) * -1);
-  --popover-bottom-start-left: calc(var(--spacing-small) * -1);
-  --popover-bottom-start-top: calc(100% + var(--spacing-small));
-  --popover-color-dark: var(--color-light-carbon-100);
-  --popover-color: var(--color-white);
+
   --popover-content-padding: var(--spacing-small);
-  --popover-left-end-bottom: calc(var(--spacing-tiny) * -1);
-  --popover-left-middle-top: 50%;
-  --popover-left-middle-transform: translateY(-50%);
-  --popover-left-right: calc(100% + var(--spacing-small));
-  --popover-left-start-top: calc(var(--spacing-tiny) * -1);
+
   --popover-link-active-background: var(--color-light-smoke-100);
   --popover-link-active-border-color: var(--color-light-grey-50);
   --popover-link-border-radius-bottom:
@@ -74,17 +87,39 @@
   --popover-link-hover-background: var(--color-light-smoke-40);
   --popover-link-hover-border-color: var(--color-light-steel-100);
   --popover-link-padding: var(--spacing-small);
+  --popover-link-text-color: var(--color-light-chromium-100);
+
+  --popover-border-color-dark: var(--popover-color-dark);
+  --popover-child-border-color-dark: var(--color-light-steel-200);
+  --popover-child-border-style-dark: dashed;
+  --popover-child-border-width-dark: 1px 0 0;
+  --popover-color-dark: var(--color-light-carbon-100);
   --popover-link-text-color-dark: var(--color-white);
   --popover-link-text-color-hover-dark: var(--color-light-greenish-100);
-  --popover-link-text-color: var(--color-light-chromium-100);
+
+  --popover-bottom-center-left: 50%;
+  --popover-bottom-center-transform: translateX(-50%);
+  --popover-bottom-end-right: calc(var(--spacing-small) * -1);
+  --popover-bottom-start-left: calc(var(--spacing-small) * -1);
+  --popover-bottom-start-top: calc(100% + var(--spacing-small));
+
+  --popover-left-end-bottom: calc(var(--spacing-tiny) * -1);
+  --popover-left-middle-top: 50%;
+  --popover-left-middle-transform: translateY(-50%);
+  --popover-left-right: calc(100% + var(--spacing-small));
+  --popover-left-start-top: calc(var(--spacing-tiny) * -1);
+
   --popover-right-end-bottom: calc(var(--spacing-tiny) * -1);
   --popover-right-left: calc(100% + var(--spacing-small));
   --popover-right-middle-top: 50%;
   --popover-right-middle-transform: translateY(-50%);
   --popover-right-start-top: calc(var(--spacing-tiny) * -1);
+
   --popover-top-bottom: calc(100% + var(--spacing-small));
   --popover-top-center-left: 50%;
   --popover-top-center-transform: translateX(-50%);
   --popover-top-end-right: calc(var(--spacing-tiny) * -1);
   --popover-top-start-left: calc(var(--spacing-tiny) * -1);
+
+  --popover-z-index: 110;
 }


### PR DESCRIPTION
- fix z-index value.
- remove background gradient on base dark.
- remove border none from all selectors.
- add border none on first-child with base dark.
- add border-bottom only when first-child is not a only-child and `Popover` has no base dark.
- refactor `:before` values to `inherit`
- refactor `:hover`, `:focus` and `:active: states

resolve pagarme/pilot#762