### PR TITLE
table: refactor style

### DIFF
--- a/src/icons/table/index.js
+++ b/src/icons/table/index.js
@@ -1,14 +1,12 @@
 import React from 'react'
 import IconArrowDown from 'emblematic-icons/svg/ChevronDown24.svg'
 import IconArrowUp from 'emblematic-icons/svg/ChevronUp24.svg'
-import IconLongArrowDown from 'emblematic-icons/svg/ArrowDown24.svg'
-import IconLongArrowUp from 'emblematic-icons/svg/ArrowUp24.svg'
 import IconSort from 'emblematic-icons/svg/OrderTable24.svg'
 
 module.exports = {
   expand: <IconArrowDown width="12px" height="12px" />,
   collapse: <IconArrowUp width="12px" height="12px" />,
-  descending: <IconLongArrowDown width="12px" height="12px" />,
-  ascending: <IconLongArrowUp width="12px" height="12px" />,
+  descending: <IconArrowDown width="12px" height="12px" />,
+  ascending: <IconArrowUp width="12px" height="12px" />,
   orderable: <IconSort width="12px" height="12px" />,
 }

--- a/src/styles/table/head.css
+++ b/src/styles/table/head.css
@@ -44,17 +44,4 @@
 
 .tableHead .active {
   color: var(--head-th-active-color);
-  position: relative;
-
-  &:before {
-    content: "";
-    background-image: var(--head-th-active-border-bottom-color);
-    bottom: 0;
-    height: var(--head-th-active-border-bottom-height);
-    left: 0;
-    margin: 0 auto;
-    position: absolute;
-    right: 0;
-    width: var(--head-th-active-border-bottom-width);
-  }
 }

--- a/src/styles/table/index.css
+++ b/src/styles/table/index.css
@@ -47,5 +47,7 @@
   color: var(--body-td-color);
   font-size: var(--body-td-font-size);
   padding: var(--body-td-padding);
+  overflow: hidden;
   position: relative;
+  text-overflow: ellipsis;
 }

--- a/src/styles/table/properties.css
+++ b/src/styles/table/properties.css
@@ -3,7 +3,7 @@
 @import "../spacing.css";
 
 :root {
-  --table-border: solid 1px var(--color-light-grey-50);
+  --table-border: solid 1px #e1e5e8;
   --table-font-family: var(--body-font-family);
   --table-font-size: 14px;
   --table-width: 100%;
@@ -13,15 +13,15 @@
   --body-td-padding: var(--spacing-small);
 
   --body-tr-even-background-color: var(--color-white);
-  --body-tr-even-border: 1px solid var(--color-light-grey-50);
+  --body-tr-even-border: var(--table-border);
   --body-tr-expanded-hover-border-width: 0 1px 1px;
   --body-tr-first-child-hover-border-width: 1px 0 1px 1px;
   --body-tr-height: 68px;
   --body-tr-hover-border-color: var(--color-light-greenish-100);
   --body-tr-hover-border-width: 1px 0;
   --body-tr-last-child-hover-border-width: 1px 1px 1px 0;
-  --body-tr-odd-background-color: var(--color-light-smoke-50);
-  --body-tr-odd-border: 1px solid var(--color-light-grey-50);
+  --body-tr-odd-background-color: #f7f7f7;
+  --body-tr-odd-border: var(--table-border);
 
   --expandable-row-li-padding: 0 20px;
   --expandable-row-padding: 21px 24px 0 27px;
@@ -34,23 +34,20 @@
   --footer-row-font-weight: bold;
   --footer-row-text-transform: uppercase;
 
-  --head-th-active-border-bottom-color: var(--color-light-greenish-gradient);
-  --head-th-active-border-bottom-height: 2px;
-  --head-th-active-border-bottom-width: calc(100% - 1px);
   --head-th-active-color: var(--color-light-greenish-100);
   --head-th-color: var(--color-light-steel-100);
   --head-th-font-size: 12px;
   --head-th-font-weight: 600;
   --head-th-line-height: normal;
   --head-th-padding: var(--spacing-small);
-  --head-th-separator-border: solid 1px var(--color-light-grey-50);
+  --head-th-separator-border: solid 1px #e1e5e8;
   --head-th-separator-height: calc(100% - 24px);
   --head-th-svg-margin: 10px;
   --head-th-text-transform: uppercase;
 
-  --head-tr-background-color: var(--color-light-smoke-100);
-  --head-tr-border: solid 1px var(--color-light-iron-50);
-  --head-tr-height: 66px;
+  --head-tr-background-color: #f7f7f7;
+  --head-tr-border: var(--table-border);
+  --head-tr-height: 62px;
 
   --hover-row-border-width: 1px 0 0;
   --hover-row-first-child-border-width: 1px 0 0 1px;


### PR DESCRIPTION
- Refactor background-color
- Refactor border-color
- Refactor `head` height
- Refactor `descending` and `ascending` icons
- Remove active `th` green line
- Add text-overflow to `item`
- Solves part of https://github.com/pagarme/pilot/issues/742
  
The issue https://github.com/pagarme/former-kit/issues/176 was created to complement this one because we had some problems with truncate items in columns and child tooltips using only css.

<img width="1174" alt="screen shot 2018-07-10 at 02 43 44" src="https://user-images.githubusercontent.com/14945222/42491523-73d57da8-83eb-11e8-9cef-b8f06a1921f7.png">
