### PR TITLE
alert: add base dark

### DIFF
--- a/src/styles/alert/index.css
+++ b/src/styles/alert/index.css
@@ -18,11 +18,13 @@
 }
 
 .dark {
+  background-color: var(--alert-dark-background-color);
   border: var(--alert-dark-border);
   color: var(--alert-dark-color);
 }
 
 .light {
+  background-color: var(--alert-light-background-color);
   border: var(--alert-light-border);
   color: var(--alert-light-color);
 }
@@ -36,26 +38,30 @@
 }
 
 .icon {
-  height: var(--alert-icon-height);
-  width: var(--alert-icon-width);
-  display: flex;
   align-items: center;
-  justify-content: center;
+  border-radius: var(--alert-icon-border-radius);
+  color: var(--alert-icon-color);
+  display: flex;
   font-size: var(--alert-icon-size);
+  height: var(--alert-icon-height);
+  justify-content: center;
+  margin-left: var(--alert-icon-margin-left);
+  margin-right: var(--alert-icon-margin-right);
+  width: var(--alert-icon-width);
 }
 
 .warning {
-  color: var(--alert-warning-color);
+  background-color: var(--alert-warning-color);
 }
 
 .info {
-  color: var(--alert-info-color);
+  background-color: var(--alert-info-color);
 }
 
 .error {
-  color: var(--alert-error-color);
+  background-color: var(--alert-error-color);
 }
 
 .success {
-  color: var(--alert-success-color);
+  background-color: var(--alert-success-color);
 }

--- a/src/styles/alert/index.css
+++ b/src/styles/alert/index.css
@@ -7,8 +7,7 @@
 
 .alert {
   align-items: center;
-  background-color: var(--alert-background-color);
-  border: var(--alert-border);
+  background-color: transparent;
   border-radius: var(--alert-border-radius);
   box-sizing: border-box;
   display: flex;
@@ -18,13 +17,22 @@
   width: 100%;
 }
 
+.dark {
+  border: var(--alert-dark-border);
+  color: var(--alert-dark-color);
+}
+
+.light {
+  border: var(--alert-light-border);
+  color: var(--alert-light-color);
+}
+
 .content {
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
   margin-right: var(--alert-content-margin-right);
-  color: var(--alert-color);
 }
 
 .icon {

--- a/src/styles/alert/properties.css
+++ b/src/styles/alert/properties.css
@@ -1,4 +1,5 @@
 @import "../colors.css";
+@import "../spacing.css";
 @import "../typography.css";
 
 :root {
@@ -6,27 +7,29 @@
   --alert-margin: 0;
   --alert-content-margin-right: var(--spacing-small);
 
-  --alert-dark-background-color: var(--color-light-carbon-100);
-  --alert-light-background-color: var(--color-white);
-
   --alert-border-radius: 3px;
-  --alert-dark-border: 1px solid var(--color-light-steel-200);
-  --alert-light-border: 1px solid var(--color-light-iron-50);
 
+  --alert-dark-background-color: var(--color-light-carbon-100);
+  --alert-dark-border: 1px solid var(--color-light-steel-200);
   --alert-dark-color: var(--color-white);
+
+  --alert-light-background-color: var(--color-white);
+  --alert-light-border: 1px solid var(--color-light-iron-50);
   --alert-light-color: var(--color-light-steel-100);
 
-  --alert-error-color: var(--color-light-error);
   --alert-font-family: var(--title-font-family);
   --alert-font-size: 16px;
 
-  --alert-icon-height: 100%;
+  --alert-icon-border-radius: var(--alert-border-radius);
+  --alert-icon-color: var(--color-white);
+  --alert-icon-height: calc(100% - 2px);
+  --alert-icon-margin-left: 1px;
+  --alert-icon-margin-right: var(--spacing-tiny);
   --alert-icon-size: 16px;
   --alert-icon-width: 48px;
-  --alert-secondary-icon-color: var(--color-white);
 
+  --alert-error-color: var(--color-light-error);
   --alert-info-color: var(--color-light-info);
-
   --alert-success-color: var(--color-light-success);
   --alert-warning-color: var(--color-light-warning);
 }

--- a/src/styles/alert/properties.css
+++ b/src/styles/alert/properties.css
@@ -2,21 +2,31 @@
 @import "../typography.css";
 
 :root {
-  --alert-background-color: var(--color-white);
-  --alert-border-radius: 3px;
-  --alert-border: 1px solid var(--color-light-iron-50);
-  --alert-color: var(--color-light-steel-100);
+  --alert-height: 48px;
+  --alert-margin: 0;
   --alert-content-margin-right: var(--spacing-small);
+
+  --alert-dark-background-color: var(--color-light-carbon-100);
+  --alert-light-background-color: var(--color-white);
+
+  --alert-border-radius: 3px;
+  --alert-dark-border: 1px solid var(--color-light-steel-200);
+  --alert-light-border: 1px solid var(--color-light-iron-50);
+
+  --alert-dark-color: var(--color-white);
+  --alert-light-color: var(--color-light-steel-100);
+
   --alert-error-color: var(--color-light-error);
   --alert-font-family: var(--title-font-family);
   --alert-font-size: 16px;
-  --alert-height: 48px;
+
   --alert-icon-height: 100%;
   --alert-icon-size: 16px;
   --alert-icon-width: 48px;
-  --alert-info-color: var(--color-light-info);
-  --alert-margin: 0;
   --alert-secondary-icon-color: var(--color-white);
+
+  --alert-info-color: var(--color-light-info);
+
   --alert-success-color: var(--color-light-success);
   --alert-warning-color: var(--color-light-warning);
 }


### PR DESCRIPTION
## Context
Refactor `Alert` component to use the Dark base.

## Checklist
- [x] Add Base Dark class to `former-kit-skin`
- [x] Add Base Dark props to Alert component
- [x] Add Dark and Light bases in Former-kit Storybook
- [X] Refactor icon background-color

## Linked Issues
- [x] Resolves pagarme/former-kit#191 in `former-kit` repository.
