### PR TITLE
input: add base dark

### DIFF
--- a/src/styles/form-fields/input/index.css
+++ b/src/styles/form-fields/input/index.css
@@ -26,15 +26,6 @@
   letter-spacing: var(--input-container-letter-spacing);
 }
 
-.light {
-  color: var(--form-item-light-color);
-
-  & .container > textarea,
-  & .container > input {
-    color: var(--form-placeholder-light-color);
-  }
-}
-
 .dark {
   color: var(--form-item-dark-color);
 
@@ -45,6 +36,62 @@
 
   & .container > label {
     color: var(--form-item-dark-label-color);
+  }
+
+  & .secondaryText {
+    color: var(--form-item-dark-color);
+  }
+
+  &.disabled .secondaryText {
+    color: var(--form-dark-color-disabled);
+  }
+
+  & .container > textarea:disabled,
+  & .container > input:disabled {
+    border-color: var(--form-dark-border-color-disabled);
+    color: var(--form-dark-color-disabled);
+  }
+
+  & .container > textarea:disabled ~ label,
+  & .container > input:disabled ~ label {
+    color: var(--form-dark-color-disabled);
+  }
+
+  & .disabled .icon {
+    color: var(--form-icon-color);
+  }
+}
+
+.light {
+  color: var(--form-item-light-color);
+
+  & .container > textarea,
+  & .container > input {
+    color: var(--form-placeholder-light-color);
+  }
+
+  & .secondaryText {
+    color: var(--form-item-light-color);
+  }
+
+  &.disabled .secondaryText {
+    color: var(--form-light-color-disabled);
+  }
+
+  & .container > textarea:disabled,
+  & .container > input:disabled {
+    border-color: var(--form-light-color-disabled);
+    color: var(--form-light-color-disabled);
+  }
+
+  & .disabled .secondaryText,
+  & .container > textarea:disabled ~ label,
+  & .container > input:disabled ~ label {
+    color: var(--form-light-color-disabled);
+  }
+
+  & .disabled .icon {
+    color: var(--form-icon-color);
   }
 }
 
@@ -98,7 +145,6 @@
 }
 
 .secondaryText {
-  color: var(--input-label-color);
   font-size: var(--input-secondary-text-font-size);
   margin: 0;
   margin-top: var(--input-secondary-text-margin-top);
@@ -208,20 +254,4 @@
 .container > input:disabled,
 .container > textarea:disabled {
   cursor: not-allowed;
-}
-
-.container > textarea:disabled,
-.container > input:disabled {
-  border-color: var(--input-textarea-disabled-border-color);
-  color: var(--input-color-disabled);
-}
-
-.disabled .secondaryText,
-.container > textarea:disabled ~ label,
-.container > input:disabled ~ label {
-  color: var(--input-color-disabled);
-}
-
-.disabled .icon {
-  color: var(--input-color-disabled);
 }

--- a/src/styles/form-fields/input/index.css
+++ b/src/styles/form-fields/input/index.css
@@ -80,7 +80,7 @@
 
   & .container > textarea:disabled,
   & .container > input:disabled {
-    border-color: var(--form-light-color-disabled);
+    border-color: var(--form-light-border-color-disabled);
     color: var(--form-light-color-disabled);
   }
 

--- a/src/styles/form-fields/input/index.css
+++ b/src/styles/form-fields/input/index.css
@@ -26,6 +26,28 @@
   letter-spacing: var(--input-container-letter-spacing);
 }
 
+.light {
+  color: var(--form-item-light-color);
+
+  & .container > textarea,
+  & .container > input {
+    color: var(--form-placeholder-light-color);
+  }
+}
+
+.dark {
+  color: var(--form-item-dark-color);
+
+  & .container > textarea,
+  & .container > input {
+    color: var(--form-placeholder-dark-color);
+  }
+
+  & .container > label {
+    color: var(--form-item-dark-label-color);
+  }
+}
+
 .container > textarea,
 .container > input {
   background: none;

--- a/src/styles/form-fields/properties.css
+++ b/src/styles/form-fields/properties.css
@@ -8,12 +8,20 @@
   --form-item-border-color: var(--color-light-grey-50);
   --form-item-border-radius: 3px;
   --form-item-error-color: var(--color-light-error);
+
   --form-item-font-family: var(--body-font-family);
   --form-item-font-size: 14px;
+
+  --form-icon-color: var(--color-light-grey-50);
 
   --form-item-dark-label-color: var(--color-light-silver-100);
   --form-item-label-color: var(--color-light-chromium-100);
 
   --form-item-secondary-font-size: 12px;
-  --form-item-color-disabled: var(--color-light-iron-50);
+
+  --form-dark-border-color-disabled: var(--color-light-grey-100);
+  --form-light-border-color-disabled: var(--color-light-iron-50);
+
+  --form-dark-color-disabled: var(--color-light-steel-100);
+  --form-light-color-disabled: var(--color-light-silver-100);
 }

--- a/src/styles/form-fields/properties.css
+++ b/src/styles/form-fields/properties.css
@@ -1,10 +1,19 @@
 :root {
+  --form-item-dark-color: var(--color-light-silver-100);
+  --form-item-light-color: var(--color-light-chromium-100);
+
+  --form-placeholder-dark-color: var(--color-white);
+  --form-placeholder-light-color: var(--color-light-steel-100);
+
   --form-item-border-color: var(--color-light-grey-50);
   --form-item-border-radius: 3px;
   --form-item-error-color: var(--color-light-error);
   --form-item-font-family: var(--body-font-family);
   --form-item-font-size: 14px;
+
+  --form-item-dark-label-color: var(--color-light-silver-100);
   --form-item-label-color: var(--color-light-chromium-100);
+
   --form-item-secondary-font-size: 12px;
   --form-item-color-disabled: var(--color-light-iron-50);
 }

--- a/src/styles/input/index.css
+++ b/src/styles/input/index.css
@@ -2,6 +2,11 @@
 @import "./properties.css";
 @import "../z-index.css";
 
+.input,
+.input * {
+  box-sizing: border-box;
+}
+
 .input {
   background-color: var(--input-background-color);
   border-color: var(--input-border-color);
@@ -19,9 +24,22 @@
   z-index: var(--input-z-index);
 }
 
-.input,
-.input * {
-  box-sizing: border-box;
+.dark {
+  color: var(--input-dark-color);
+
+  & .container > textarea,
+  & .container > input {
+    color: var(--input-dark-color);
+  }
+}
+
+.light {
+  color: var(--input-light-color);
+
+  & .container > textarea,
+  & .container > input {
+    color: var(--input-light-color);
+  }
 }
 
 .boxContainer {
@@ -47,7 +65,6 @@
 .container > input {
   background: none;
   border: none;
-  color: var(--input-color);
   display: block;
   font-size: var(--input-font-size);
   flex: 1;

--- a/src/styles/input/index.css
+++ b/src/styles/input/index.css
@@ -32,9 +32,13 @@
     color: var(--input-dark-color);
   }
 
-  & .disabled,
-  & .disabled:hover {
-    border-color: var(--input-dark-color-disabled);
+  & .displayPasswordIcon {
+    color: var(--input-dark-color);
+  }
+
+  &.disabled,
+  &.disabled:hover {
+    border-color: var(--input-dark-border-color-disabled);
   }
 
   & .container > input:disabled,
@@ -57,9 +61,13 @@
     color: var(--input-light-color);
   }
 
+  & .displayPasswordIcon {
+    color: var(--input-light-color);
+  }
+
   &.disabled,
   &.disabled:hover {
-    border-color: var(--input-light-color-disabled);
+    border-color: var(--input-light-border-color-disabled);
   }
 
   & .container > input:disabled,

--- a/src/styles/input/index.css
+++ b/src/styles/input/index.css
@@ -31,6 +31,22 @@
   & .container > input {
     color: var(--input-dark-color);
   }
+
+  & .disabled,
+  & .disabled:hover {
+    border-color: var(--input-dark-color-disabled);
+  }
+
+  & .container > input:disabled,
+  & .container > textarea:disabled,
+  & .container > input:disabled::placeholder,
+  & .container > textarea:disabled::placeholder {
+    color: var(--input-dark-color-disabled);
+  }
+
+  & .disabled .icon svg {
+    color: var(--input-dark-color-disabled);
+  }
 }
 
 .light {
@@ -39,6 +55,22 @@
   & .container > textarea,
   & .container > input {
     color: var(--input-light-color);
+  }
+
+  &.disabled,
+  &.disabled:hover {
+    border-color: var(--input-light-color-disabled);
+  }
+
+  & .container > input:disabled,
+  & .container > textarea:disabled,
+  & .container > input:disabled::placeholder,
+  & .container > textarea:disabled::placeholder {
+    color: var(--input-light-color-disabled);
+  }
+
+  & .disabled .icon svg {
+    color: var(--input-light-color-disabled);
   }
 }
 
@@ -147,19 +179,9 @@
 
 /* disabled */
 
-.disabled,
-.disabled:hover {
-  border-color: var(--input-color-disabled);
-}
-
 .container > input:disabled,
 .container > textarea:disabled,
 .container > input:disabled::placeholder,
 .container > textarea:disabled::placeholder {
   cursor: not-allowed;
-  color: var(--input-color-disabled);
-}
-
-.disabled .icon svg {
-  color: var(--input-color-disabled);
 }

--- a/src/styles/input/properties.css
+++ b/src/styles/input/properties.css
@@ -2,16 +2,22 @@
 @import "../typography.css";
 
 :root {
-  --input-background-color: var(--color-white);
-  --input-border-color: var(--color-light-grey-50);
+  --input-background-color: transparent;
+
   --input-border-radius: 3px;
   --input-border-style: solid;
   --input-border-width: 1px;
-  --input-color: var(--color-light-steel-100);
+  --input-border-color: var(--color-light-grey-50);
+
+  --input-dark-color: var(--color-light-silver-100);
+  --input-light-color: var(--color-light-steel-100);
+
   --input-container-letter-spacing: var(--letter-spacing);
   --input-container-padding: 0 5px;
+
   --input-font-family: var(--title-font-family);
   --input-font-size: 14px;
+
   --input-height: var(--spacing-large);
 
   --input-multiline-font-size: 14px;

--- a/src/styles/input/properties.css
+++ b/src/styles/input/properties.css
@@ -34,5 +34,6 @@
 
   --input-color-error: var(--color-light-error);
 
-  --input-color-disabled: var(--color-light-iron-50);
+  --input-dark-color-disabled: var(--color-light-grey-100);
+  --input-light-color-disabled: var(--color-light-iron-50);
 }

--- a/src/styles/input/properties.css
+++ b/src/styles/input/properties.css
@@ -34,6 +34,9 @@
 
   --input-color-error: var(--color-light-error);
 
-  --input-dark-color-disabled: var(--color-light-grey-100);
-  --input-light-color-disabled: var(--color-light-iron-50);
+  --input-dark-border-color-disabled: var(--color-light-grey-100);
+  --input-light-border-color-disabled: var(--color-light-iron-50);
+
+  --input-dark-color-disabled: var(--color-light-steel-100);
+  --input-light-color-disabled: var(--color-light-silver-100);
 }


### PR DESCRIPTION
## Context
Refactor `Input` component to use the Dark base.

## Checklist
- [x] Add Base Dark class to `former-kit-skin`
- [x] Add Base Dark props to Input component
- [x] Add Dark and Light bases in Former-Kit Storybook

## Linked Issues
- [x] Resolves pagarme/former-kit#193 in `former-kit` repository.
