### PR TITLE
Modal - Fix vertical alignment

### DIFF
--- a/src/styles/modal/index.css
+++ b/src/styles/modal/index.css
@@ -15,7 +15,6 @@
   outline: none;
   overflow: unset;
   position: relative;
-  transform: translateY(var(--modal-position-top));
   width: var(--modal-inner-width);
 
   & .title,
@@ -30,7 +29,7 @@
 }
 
 .overlay {
-  align-items: baseline;
+  align-items: center;
   background: var(--modal-overlay-background);
   bottom: 0;
   display: flex;

--- a/src/styles/modal/properties.css
+++ b/src/styles/modal/properties.css
@@ -12,7 +12,6 @@
   --modal-inner-width: 580px;
   --modal-overlay-background: rgba(var(--color-black), 0.7);
   --modal-padding: var(--spacing-small);
-  --modal-position-top: 145px;
 
   --modal-child-padding:
     0


### PR DESCRIPTION
## Context
Fixes modal vertical alignment by removing `transformY` usage and using overlay's `align-items` instead.

## Checklist
- [x] Modal is vertically aligned on center