### PR TITLE
flexbox: fix container width

### DIFF
--- a/src/styles/flexbox/index.css
+++ b/src/styles/flexbox/index.css
@@ -1,6 +1,7 @@
 .flexbox {
   display: flex;
   flex-wrap: wrap;
+  width: 100%;
 }
 
 .alignCenter {


### PR DESCRIPTION
## Context
In **Pilot** project I found an error using flexbox, the container don't ocuppy all width size because the parent container has flexbox too, so to fix this I added a width with 100% in the style for flexbox container.

## Checklist
- [x] fix width flexbox container