### PR TITLE
popover: refactor alignment

### DIFF
--- a/src/styles/popover/index.css
+++ b/src/styles/popover/index.css
@@ -1,7 +1,9 @@
 @import "./properties.css";
 
 .target {
+  align-items: center;
   display: inline-flex;
+  justify-content: center;
   outline: none;
   position: relative;
 }
@@ -118,8 +120,6 @@
 }
 
 .bottomCenter {
-  left: var(--popover-bottom-center-left);
-  transform: var(--popover-bottom-center-transform);
 
   &:before {
     left: var(--popover-arrow-bottom-center-left);
@@ -157,8 +157,6 @@
 }
 
 .rightMiddle {
-  top: var(--popover-right-middle-top);
-  transform: var(--popover-right-middle-transform);
 
   &:before {
     top: var(--popover-arrow-right-middle-top);
@@ -194,8 +192,6 @@
 }
 
 .leftMiddle {
-  top: var(--popover-left-middle-top);
-  transform: var(--popover-left-middle-transform);
 
   &:before {
     top: var(--popover-arrow-left-middle-top);
@@ -231,8 +227,6 @@
 }
 
 .topCenter {
-  left: var(--popover-top-center-left);
-  transform: var(--popover-top-center-transform);
 
   &:before {
     left: var(--popover-arrow-top-center-left);

--- a/src/styles/popover/properties.css
+++ b/src/styles/popover/properties.css
@@ -98,27 +98,19 @@
   --popover-link-text-color-dark: var(--color-white);
   --popover-link-text-color-hover-dark: var(--color-light-greenish-100);
 
-  --popover-bottom-center-left: 50%;
-  --popover-bottom-center-transform: translateX(-50%);
   --popover-bottom-end-right: calc(var(--spacing-small) * -1);
   --popover-bottom-start-left: calc(var(--spacing-small) * -1);
   --popover-bottom-start-top: calc(100% + var(--spacing-small));
 
   --popover-left-end-bottom: calc(var(--spacing-tiny) * -1);
-  --popover-left-middle-top: 50%;
-  --popover-left-middle-transform: translateY(-50%);
   --popover-left-right: calc(100% + var(--spacing-small));
   --popover-left-start-top: calc(var(--spacing-tiny) * -1);
 
   --popover-right-end-bottom: calc(var(--spacing-tiny) * -1);
   --popover-right-left: calc(100% + var(--spacing-small));
-  --popover-right-middle-top: 50%;
-  --popover-right-middle-transform: translateY(-50%);
   --popover-right-start-top: calc(var(--spacing-tiny) * -1);
 
   --popover-top-bottom: calc(100% + var(--spacing-small));
-  --popover-top-center-left: 50%;
-  --popover-top-center-transform: translateX(-50%);
   --popover-top-end-right: calc(var(--spacing-tiny) * -1);
   --popover-top-start-left: calc(var(--spacing-tiny) * -1);
 


### PR DESCRIPTION
<!-- IMPORTANT: Remove the items which you're not using. -->

## Context
This PR removes the `transform: translate` from middle and center type popovers to use transform to animate them.
<!-- What problem are you trying to solve? -->

## Checklist
- [X] Add `align-items: center` and `justify-content: center` to the target
- [X] Remove transform `left`, `top` and `transform `properties` from `center` and `middle` classes.
<!-- Describe the main changes that your PR does. -->

## Linked Issues
- Helps https://github.com/pagarme/pilot/issues/856
<!-- Add the respective issues linked to this PR -->