### PR TITLE
tooltip: refactor alignment

### DIFF
--- a/src/styles/tooltip/index.css
+++ b/src/styles/tooltip/index.css
@@ -1,7 +1,9 @@
 @import "./properties.css";
 
 .target {
+  align-items: center;
   display: inline-flex;
+  justify-content: center;
   position: relative;
 }
 
@@ -44,123 +46,115 @@
 .rightStart {
   top: var(--tooltip-right-start-top);
   left: var(--tooltip-right-start-left);
-}
 
-.rightStart:before {
-  right: var(--tooltip-arrow-align-box);
-  top: var(--tooltip-arrow-right-start-top);
+  &:before {
+    right: var(--tooltip-arrow-align-box);
+    top: var(--tooltip-arrow-right-start-top);
+  }
 }
 
 .rightMiddle {
-  top: 50%;
-  transform: translateY(-50%);
   left: var(--tooltip-right-middle-left);
-}
 
-.rightMiddle:before {
-  right: var(--tooltip-arrow-align-box);
-  top: var(--tooltip-arrow-right-middle-top);
+  &:before {
+    right: var(--tooltip-arrow-align-box);
+    top: var(--tooltip-arrow-right-middle-top);
+  }
 }
 
 .rightEnd {
   bottom: var(--tooltip-right-end-bottom);
   left: var(--tooltip-right-end-left);
-}
 
-.rightEnd:before {
-  bottom: var(--tooltip-arrow-right-end-bottom);
-  right: var(--tooltip-arrow-align-box);
+  &:before {
+    bottom: var(--tooltip-arrow-right-end-bottom);
+    right: var(--tooltip-arrow-align-box);
+  }
 }
 
 .leftStart {
   right: var(--tooltip-left-start-right);
   top: var(--tooltip-left-start-top);
-}
 
-.leftStart:before {
-  left: var(--tooltip-arrow-align-box);
-  top: var(--tooltip-arrow-left-start-top);
+  &:before {
+    left: var(--tooltip-arrow-align-box);
+    top: var(--tooltip-arrow-left-start-top);
+  }
 }
 
 .leftMiddle {
-  top: 50%;
-  transform: translateY(-50%);
   right: var(--tooltip-left-middle-right);
-}
 
-.leftMiddle:before {
-  top: var(--tooltip-arrow-right-middle-top);
-  left: var(--tooltip-arrow-align-box);
+  &:before {
+    top: var(--tooltip-arrow-right-middle-top);
+    left: var(--tooltip-arrow-align-box);
+  }
 }
 
 .leftEnd {
   bottom: var(--tooltip-left-end-bottom);
   right: var(--tooltip-left-end-right);
-}
 
-.leftEnd:before {
-  bottom: var(--tooltip-arrow-left-end-bottom);
-  left: var(--tooltip-arrow-align-box);
+  &:before {
+    bottom: var(--tooltip-arrow-left-end-bottom);
+    left: var(--tooltip-arrow-align-box);
+  }
 }
 
 .bottomStart {
   left: var(--tooltip-bottom-start-left);
   top: var(--tooltip-bottom-start-top);
-}
 
-.bottomStart:before {
-  bottom: var(--tooltip-arrow-align-box);
-  left: var(--tooltip-arrow-bottom-start-left);
+  &:before {
+    bottom: var(--tooltip-arrow-align-box);
+    left: var(--tooltip-arrow-bottom-start-left);
+  }
 }
 
 .bottomCenter {
-  left: 50%;
-  transform: translateX(-50%);
   top: var(--tooltip-bottom-center-top);
-}
 
-.bottomCenter:before {
-  bottom: var(--tooltip-arrow-align-box);
-  left: var(--tooltip-arrow-bottom-center-left);
+  &:before {
+    bottom: var(--tooltip-arrow-align-box);
+    left: var(--tooltip-arrow-bottom-center-left);
+  }
 }
 
 .bottomEnd {
   right: var(--tooltip-bottom-end-right);
   top: var(--tooltip-bottom-end-top);
-}
 
-.bottomEnd:before {
-  bottom: var(--tooltip-arrow-align-box);
-  right: var(--tooltip-arrow-bottom-end-right);
+  &:before {
+    bottom: var(--tooltip-arrow-align-box);
+    right: var(--tooltip-arrow-bottom-end-right);
+  }
 }
 
 .topStart {
   left: var(--tooltip-top-start-left);
   bottom: var(--tooltip-top-start-bottom);
-}
 
-.topStart:before {
-  top: var(--tooltip-arrow-align-box);
-  left: var(--tooltip-arrow-top-start-left);
+  &:before {
+    top: var(--tooltip-arrow-align-box);
+    left: var(--tooltip-arrow-top-start-left);
+  }
 }
 
 .topCenter {
-  left: 50%;
-  transform: translateX(-50%);
   bottom: var(--tooltip-top-center-bottom);
-}
 
-.topCenter:before {
-  top: var(--tooltip-arrow-align-box);
-  left: var(--tooltip-arrow-top-center-left);
+  &:before {
+    top: var(--tooltip-arrow-align-box);
+    left: var(--tooltip-arrow-top-center-left);
+  }
 }
 
 .topEnd {
   right: var(--tooltip-top-end-right);
   bottom: var(--tooltip-top-end-bottom);
-}
 
-.topEnd:before {
-  top: var(--tooltip-arrow-align-box);
-  right: var(--tooltip-arrow-top-end-right);
+  &:before {
+    top: var(--tooltip-arrow-align-box);
+    right: var(--tooltip-arrow-top-end-right);
+  }
 }


### PR DESCRIPTION
<!-- IMPORTANT: Remove the items which you're not using. -->

## Context
This PR removes the `transform: translate` from middle and center type tooltips to use transform to animate them.
<!-- What problem are you trying to solve? -->

## Checklist
- [X] Add `align-items: center` and `justify-content: center` to the target
- [X] Remove transform `left`, `top` and `transform `properties` from `center` and `middle` classes
- [X] Nest pseudo-elements
<!-- Describe the main changes that your PR does. -->

## Linked Issues
- Helps https://github.com/pagarme/pilot/issues/856
<!-- Add the respective issues linked to this PR -->