### PR TITLE
Modal: add transition

### DIFF
--- a/src/styles/modal/index.css
+++ b/src/styles/modal/index.css
@@ -15,6 +15,7 @@
   outline: none;
   overflow: unset;
   position: relative;
+  transform: var(--modal-content-transform);
   width: var(--modal-inner-width);
 
   & .title,
@@ -28,6 +29,15 @@
   }
 }
 
+.modalAfterOpen {
+  transition: var(--modal-content-transition);
+  transform: var(--modal-content-transform-none);
+}
+
+.modalBeforeClose {
+  transform: var(--modal-content-transform);
+}
+
 .overlay {
   align-items: center;
   background: var(--modal-overlay-background);
@@ -35,10 +45,21 @@
   display: flex;
   justify-content: center;
   left: 0;
+  opacity: var(--modal-overlay-opacity-none);
   position: fixed;
   right: 0;
   top: 0;
   z-index: var(--modal-overlay-z-index);
+}
+
+.overlayAfterOpen {
+  opacity: var(--modal-overlay-opacity);
+  will-change: opacity;
+  transition: var(--modal-overlay-transition);
+}
+
+.overlayBeforeClose {
+  opacity: var(--modal-overlay-opacity-none);
 }
 
 .centerAlign {

--- a/src/styles/modal/properties.css
+++ b/src/styles/modal/properties.css
@@ -31,4 +31,14 @@
   --modal-divider-border-style: solid;
   --modal-divider-border-width: 1px 0 0;
   --modal-divider-margin: 0 var(--spacing-small) var(--spacing-small);
+
+  --modal-overlay-opacity-none: 0;
+  --modal-overlay-opacity: 1;
+
+  --modal-overlay-transition: opacity 225ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+
+  --modal-content-transition: transform 225ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+
+  --modal-content-transform-none: translate(0, 0);
+  --modal-content-transform: translateY(100vh) translateY(-88.75px);
 }


### PR DESCRIPTION
## Context
Add transition to Modal. This PR is related to https://github.com/pagarme/pilot/pull/1014 and https://github.com/pagarme/former-kit/pull/204.

## Checklist
- [x] Add transition property to ReactModal
- [x] Add opacity in "after-open" and "before-close" properties

## Linked Issues
- [x] Resolves https://github.com/pagarme/pilot/issues/858

## How to test
- Go to `add/modal-transition` branch in all repositories
```
git checkout add/modal-transition
```
- Create a link to former-kit-skin e former-kit repositories
```
yarn link
```

- Link former-kit-skin-pagarme
```
yarn link former-kit
```

- Link former-kit-skin-pagarme inside Pilot
```
yarn link former-kit
yarn link former-kit-skin
```

- Run normally storybook at former-kit/Pilot
```
yarn storybook
```
