### PR TITLE
sidebar: refactor sidebar min-width

### DIFF
--- a/src/styles/sidebar/index.css
+++ b/src/styles/sidebar/index.css
@@ -38,8 +38,9 @@
 }
 
 .collapsed {
-  width: var(--sidebar-collapsed-width);
+  min-width: var(--sidebar-collapsed-min-width);
   transition: var(--sidebar-transition);
+  width: var(--sidebar-collapsed-width);
 
   & header {
     justify-content: center;
@@ -52,6 +53,7 @@
 }
 
 .expanded {
-  width: var(--sidebar-width);
+  min-width: var(--sidebar-expanded-min-width);
   transition: var(--sidebar-transition);
+  width: var(--sidebar-expanded-width);
 }

--- a/src/styles/sidebar/properties.css
+++ b/src/styles/sidebar/properties.css
@@ -2,9 +2,11 @@
 @import "../media.css";
 
 :root {
-  --sidebar-width: 222px;
+  --sidebar-collapsed-min-width: 78px;
+  --sidebar-expanded-min-width: 222px;
 
   --sidebar-collapsed-width: 78px;
+  --sidebar-expanded-width: 222px;
 
   --sidebar-background-color: var(--color-light-carbon-40);
 


### PR DESCRIPTION
<!-- IMPORTANT: Remove the items which you're not using. -->

## Context
After Microinteration's Sidebar merge, notice that the lower the resolution, the Sidebar breaks being "squeezed" as the page resolution gets smaller until gets invisible to the user.

## Checklist
- [ ] Change width to min-width

## Linked Issues
- [ ] Resolves https://github.com/pagarme/former-kit-skin-pagarme/issues/167

## How to test?
- Go to `fix/sidebar-min-width` branch
- Generate an .tgz file from `former-kit-skin-pagarme` repository
- Copy this file and paste in `pilot` repository
- Change the package `"former-kit-skin-pagarme": "1.1.0"` to `  "former-kit-skin-pagarme": "../../former-kit-skin-pagarme-1.1.0.tgz"`
- Delete `node_modules/` and `dist/` from `pilot/`
- Run `yarn` in `pilot` repository
- Go to `packages/pilot` and run `yarn start` :tada: 