### PR TITLE
Update version

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -10,6 +10,7 @@
           "define-mixin"
         ]
       }
-    ]
+    ],
+    "no-descending-specificity": null
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react": "16.7.0",
     "react-dom": "16.7.0",
     "stylelint": "9.10.0",
-    "stylelint-config-pagarme-react": "1.2.0"
+    "stylelint-config-pagarme-react": "2.0.0"
   },
   "peerDependencies": {
     "react": "ˆ16.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "former-kit-skin-pagarme",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A skin for former-kit based on Pagar.me's brand",
   "main": "dist/index.js",
   "repository": "https://github.com/pagarme/former-kit-skin-pagarme.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4633,24 +4633,24 @@ style-search@^0.1.0:
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
 
-stylelint-config-pagarme-react@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-pagarme-react/-/stylelint-config-pagarme-react-1.2.0.tgz#30eb00c4bcfd127b0ed1ceeed49ca605489cd087"
-  integrity sha512-KJYUZtbieTDonBukIoy4UJ1ibN9lD6d7lm72kEU1dZ3xKgkDJLmUZOVJUNECLVHmp/mnJPOwZjvHPqN2xRFVzA==
+stylelint-config-pagarme-react@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-pagarme-react/-/stylelint-config-pagarme-react-2.0.0.tgz#8e4fcdc0039969397362a5e0e17527c12517cc2b"
+  integrity sha512-E8jono2MBXEjuQrujXe9mgLPHd4yb/dpn3r5OQW8XU/b2AnSHVWrrAdWj5G/4bWYV6NDFz4rX71timmi40qXHQ==
   dependencies:
-    stylelint-config-standard "17.0.0"
+    stylelint-config-standard "18.2.0"
 
-stylelint-config-recommended@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-1.0.0.tgz#752c17fc68fa64cd5e7589e24f6e46e77e14a735"
-  integrity sha512-wp50rY5A6MWndIIkKNNzJv/S58lTvqQEriS7CXTBN1SwtoY/YjHhCLIOkjundLnUWMvJJska6GnciLbs76UQrA==
+stylelint-config-recommended@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-2.2.0.tgz#46ab139db4a0e7151fd5f94af155512886c96d3f"
+  integrity sha512-bZ+d4RiNEfmoR74KZtCKmsABdBJr4iXRiCso+6LtMJPw5rd/KnxUWTxht7TbafrTJK1YRjNgnN0iVZaJfc3xJA==
 
-stylelint-config-standard@17.0.0:
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-17.0.0.tgz#42103a090054ee2a3dde9ecaed55e5d4d9d059fc"
-  integrity sha512-G8jMZ0KsaVH7leur9XLZVhwOBHZ2vdbuJV8Bgy0ta7/PpBhEHo6fjVDaNchyCGXB5sRcWVq6O9rEU/MvY9cQDQ==
+stylelint-config-standard@18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-18.2.0.tgz#6283149aba7f64f18731aef8f0abfb35cf619e06"
+  integrity sha512-07x0TaSIzvXlbOioUU4ORkCIM07kyIuojkbSVCyFWNVgXMXYHfhnQSCkqu+oHWJf3YADAnPGWzdJ53NxkoJ7RA==
   dependencies:
-    stylelint-config-recommended "^1.0.0"
+    stylelint-config-recommended "^2.1.0"
 
 stylelint@9.10.0:
   version "9.10.0"


### PR DESCRIPTION
<!-- IMPORTANT: Remove the items which you're not using. -->
Update version from `1.2.0` to `1.3.0`  to release the truncate new component, updates the `stylelint-config-pagarme-react` plugin and disables the rule `no-descending-specificity`(this rule was disabled because it brakes with our CSS nesting usage)
