### PR TITLE
card: remove title's white-space

### DIFF
--- a/src/styles/card/index.css
+++ b/src/styles/card/index.css
@@ -59,7 +59,6 @@
 .title > h2,
 .title > h1 {
   margin: 0;
-  white-space: pre;
 
   & > svg {
     margin-right: var(--card-title-icon-margin);


### PR DESCRIPTION
## Context
In `release/v0.15.0` we have an bug on the CardTitle component of the Card presented in Dash, which makes Percy always alert.

## Checklist
- [ ] Remove `white-space: pre;` from Cards

## Linked Issues
- [ ] Resolves https://github.com/pagarme/pilot/issues/1240

## How to Test
- Go to `refactor/card-white-space` branch
- Generate an link from this repo with `yarn link`
- Go to `release/v0.15.0` of Pilot's repository
- Link this repository to Pilot with `yarn link former-kit-skin-pagarme`
- Run Pilot normally and check with this white-space persists in Card titles. :tada:
