### PR TITLE
Table PR: update column size classes

### DIFF
--- a/src/styles/table/index.css
+++ b/src/styles/table/index.css
@@ -49,3 +49,19 @@
   padding: var(--body-td-padding);
   position: relative;
 }
+
+.smallSize {
+  width: var(--column-td-size-small);
+}
+
+.mediumSize {
+  width: var(--column-td-size-medium);
+}
+
+.defaultSize {
+  width: var(--column-td-size-default);
+}
+
+.largeSize {
+  width: var(--column-td-size-large);
+}

--- a/src/styles/table/properties.css
+++ b/src/styles/table/properties.css
@@ -23,6 +23,11 @@
   --body-tr-odd-background-color: #f7f7f7;
   --body-tr-odd-border: var(--table-border);
 
+  --column-td-size-small: 74px;
+  --column-td-size-medium: 120px;
+  --column-td-size-default: 194px;
+  --column-td-size-large: 300px;
+
   --expandable-row-li-padding: 0 20px;
   --expandable-row-padding: 21px 24px 0 27px;
   --expandable-row-text-color: var(--color-light-chromium-100);


### PR DESCRIPTION
## Context
This PR solves two problems that was happening in recipients table:
- `status` column was too large for a few small information
- overlap in `id` informations when the screen size changes

This PR is part of this Card: https://github.com/pagarme/former-kit-skin-pagarme/issues/183 . It is possible to see examples of the problem there.
