### PR TITLE
SegmentedSwitch - Add styling for low relevance and tiny spacing

### DIFF
--- a/src/styles/segmented-switch/properties.css
+++ b/src/styles/segmented-switch/properties.css
@@ -31,14 +31,31 @@
   --context-switch-enter-border-style: solid;
   --context-switch-enter-border-width: 1px;
 
-  --spaced-switch-label-padding: var(--spacing-small);
+  --spaced-switch-tiny-spacing: var(--spacing-tiny);
+  --spaced-switch-small-spacing: var(--spacing-small);
+  --spaced-switch-medium-spacing: var(--spacing-medium);
+  --spaced-switch-large-spacing: var(--spacing-large);
 
-  --spaced-switch-enter-background-color-active: var(--color-light-greenish-150);
+  --spaced-switch-background: var(--color-white);
+  --spaced-switch-background-active: var(--color-light-greenish-150);
+  --spaced-switch-background-hover: var(--color-light-greenish-120);
+  --spaced-switch-background-checked: var(--color-light-greenish-gradient);
   --spaced-switch-checked-color: var(--color-white);
   --spaced-switch-disabled-color: var(--color-white);
 
-  --spaced-switch-label-background: var(--color-light-greenish-gradient);
-
   --spaced-switch-label-focus-border: 1px solid var(--color-light-greenish-150);
   --spaced-switch-label-focus-border-shadown: var(--color-light-greenish-150) 0 0 0 1px inset;
+
+  --low-relevance-spaced-switch-background: transparent;
+  --low-relevance-spaced-switch-background-active: var(--color-light-grey-50);
+  --low-relevance-spaced-switch-background-hover: var(--color-light-smoke-100);
+  --low-relevance-spaced-switch-background-checked: var(--color-light-smoke-50);
+  --low-relevance-spaced-switch-color: var(--color-light-coal-100);
+  --low-relevance-spaced-switch-checked-color: var(--color-light-carbon-40);
+
+  --low-relevance-spaced-switch-checked-label-border:
+    0 0 0 1px var(--color-white),
+    0 0 0 2px var(--color-light-steel-50);
+
+  --low-relevance-spaced-switch-label-focus-border-shadow: 0 0 0 1px var(--color-light-steel-50);
 }

--- a/src/styles/segmented-switch/spaced/index.css
+++ b/src/styles/segmented-switch/spaced/index.css
@@ -9,10 +9,6 @@
   display: inline-flex;
   height: 40px;
   user-select: none;
-
-  & .item:not(:last-child) {
-    margin-right: var(--spaced-switch-label-padding);
-  }
 }
 
 .item {
@@ -29,6 +25,7 @@
 .label {
   align-items: center;
   border: var(--context-switch-label-border);
+  border-radius: var(--context-switch-label-border-radius);
   color: var(--context-switch-label-color);
   cursor: pointer;
   display: flex;
@@ -42,10 +39,9 @@
   white-space: nowrap;
 }
 
-.item input + .label {
-  background-color: var(--spaced-switch-checked-color);
+.relevance-normal .item input + .label {
+  background-color: var(--spaced-switch-background);
   border: 1px solid var(--color-light-greenish-100);
-  border-radius: var(--context-switch-label-border-radius);
   box-sizing: border-box;
   color: var(--context-switch-enter-background-color);
   border-style: solid;
@@ -59,20 +55,41 @@
 
   &:active {
     color: var(--spaced-switch-checked-color);
-    background-color: var(--spaced-switch-enter-background-color-active);
+    background-color: var(--spaced-switch-background-active);
     border-color: var(--color-light-greenish-150);
   }
 }
 
-.item input:checked + .label {
-  background-image: var(--spaced-switch-label-background);
+.relevance-normal .item input:checked + .label {
+  background-image: var(--spaced-switch-background-checked);
   border: 1px solid;
   color: var(--spaced-switch-checked-color);
 }
 
-.item input:focus + .label {
+.relevance-normal .item input:focus + .label {
   border: var(--spaced-switch-label-focus-border);
   box-shadow: var(--spaced-switch-label-focus-border-shadown);
+}
+
+.relevance-low .item input + .label {
+  background-color: var(--low-relevance-spaced-switch-background);
+  border: 1px solid transparent;
+  color: var(--low-relevance-spaced-switch-color);
+
+  &:hover {
+    background-color: var(--low-relevance-spaced-switch-background-hover);
+  }
+
+  &:active {
+    background-color: var(--low-relevance-spaced-switch-background-active);
+  }
+}
+
+.relevance-low .item input:checked + .label {
+  background-color: var(--low-relevance-spaced-switch-background-checked);
+  background-image: none;
+  box-shadow: var(--low-relevance-spaced-switch-checked-label-border);
+  color: var(--low-relevance-spaced-switch-checked-color);
 }
 
 .disabled .item input + .label {
@@ -83,6 +100,8 @@
 
   &:hover {
     background-color: var(--context-switch-disabled-checked-background-color);
+    border: var(--context-switch-disabled-checked-label-border);
+    color: var(--context-switch-disabled-color);
   }
 }
 
@@ -95,4 +114,20 @@
   &:active {
     border: var(--context-switch-disabled-checked-label-border);
   }
+}
+
+.spacing-tiny .item:not(:last-child) {
+  margin-right: var(--spaced-switch-tiny-spacing);
+}
+
+.spacing-small .item:not(:last-child) {
+  margin-right: var(--spaced-switch-small-spacing);
+}
+
+.spacing-medium .item:not(:last-child) {
+  margin-right: var(--spaced-switch-medium-spacing);
+}
+
+.spacing-large .item:not(:last-child) {
+  margin-right: var(--spaced-switch-large-spacing);
 }


### PR DESCRIPTION
## Context
We need to add the stylings for the new props `relevance` and `spacing` implemented on `SpacedSegmentedSwitch`

## Checklist
- [x] Must have stylings for `relevance`
- [x] Must have stylings for `spacing`

## Linked Issues
- [x] Resolves https://github.com/pagarme/former-kit/issues/279

## Screenshots

### Preview:
![image](https://user-images.githubusercontent.com/18339615/60989683-f7019a80-a31c-11e9-8763-e543cb21ef98.png)

## How to test
1. Link to `former-kit/add/low-relevance-segmentedswitch`
2. Run former-kit's storybook
