### PR TITLE
Update Sidebar Header padding + add new color

### DIFF
--- a/src/styles/colors/light.css
+++ b/src/styles/colors/light.css
@@ -50,6 +50,7 @@
   --color-light-purple-100: #8459b9;
   --color-light-steel-200: #5c5c5c;
   --color-light-carbon-100: #1f1f1f;
+  --color-light-carbon-60: #2d2d2d;
   --color-light-carbon-50: #2c2c2c;
   --color-light-carbon-40: #383838;
 

--- a/src/styles/sidebar/properties.css
+++ b/src/styles/sidebar/properties.css
@@ -9,13 +9,13 @@
   --sidebar-collapsed-width: 78px;
   --sidebar-expanded-width: 222px;
 
-  --sidebar-background-color: var(--color-light-carbon-40);
+  --sidebar-background-color: var(--color-light-carbon-60);
 
   --sidebar-font-family: var(--title-font-family);
 
   --sidebar-header-height: 72px;
   --sidebar-header-text-color: var(--color-white);
-  --sidebar-header-padding: 15px;
+  --sidebar-header-padding: var(--spacing-small) var(--spacing-medium);
   --sidebar-header-border-bottom: 1px solid var(--color-light-steel-200);
 
   --sidebar-header-button-border: none;


### PR DESCRIPTION
## Context
This PR updates sidebar header's padding and adds a new color into `colors.css`.

## Checklist
- [ ] Update sidebar header's padding
- [ ] Add new color `color-light-carbon-60`

## Linked Issues
- [ ] Resolves https://github.com/pagarme/pilot/issues/1275

## How to test?
- Go to branch `update/menu-icons` 
- Update your local dependencies with `yarn`
- Generate a link with `yarn link`
- Use this link in `pilot` repository with `yarn link former-kit-skin-pagarme`
- Check if all the updates are there. That's it! :tada: 