### PR TITLE
bump react related dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "start": "env WATCH=-w run-p build:copy build:compile"
   },
   "dependencies": {
-    "emblematic-icons": "0.6.1",
-    "react-dates": "18.4.0"
+    "emblematic-icons": "0.7.1",
+    "react-dates": "18.4.1"
   },
   "devDependencies": {
     "@babel/cli": "7.2.3",
@@ -34,13 +34,13 @@
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-react": "7.14.3",
     "npm-run-all": "4.1.5",
-    "react": "16.7.0",
-    "react-dom": "16.7.0",
+    "react": "16.9.0",
+    "react-dom": "16.9.0",
     "stylelint": "10.1.0",
     "stylelint-config-pagarme-react": "2.0.0"
   },
   "peerDependencies": {
-    "react": "ˆ16.8.0",
-    "react-dom": "ˆ16.8.0"
+    "react": "ˆ16.9.0",
+    "react-dom": "ˆ16.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "former-kit-skin-pagarme",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A skin for former-kit based on Pagar.me's brand",
   "main": "dist/index.js",
   "repository": "https://github.com/pagarme/former-kit-skin-pagarme.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1679,10 +1679,10 @@ electron-to-chromium@^1.3.247:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.257.tgz#35da0ad5833b27184c8298804c498a4d2f4ed27d"
   integrity sha512-EcKVmUeHCZelPA0wnIaSmpAN8karKhKBwFb+xLUjSVZ8sGRE1l3fst1zQZ7KJUkyJ7H5edPd4RP94pzC9sG00A==
 
-emblematic-icons@0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/emblematic-icons/-/emblematic-icons-0.6.1.tgz#c9eba3cc90d818cf451cebf35b360e5e3dcf0b06"
-  integrity sha512-y9SC6R9wT5B82V0xNNmKswkf6ulB8Fbgs7oenxDsGEqUsMKBFajcwE27BlCwB7WC3bzaRZqSuQjERAI5xINoAw==
+emblematic-icons@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/emblematic-icons/-/emblematic-icons-0.7.1.tgz#2771340af07f31628cb9afc678108fa61542d76e"
+  integrity sha512-ZkPYHOhGtwltmeRHnEOA55PK4Cl5fNmTX8kkFqZ6T2MFsZFBle7h8qBfk5gcGxvfQwc/+iRQrwMOGZ86+DooRw==
 
 emoji-regex@^7.0.1, emoji-regex@^7.0.2:
   version "7.0.3"
@@ -3884,10 +3884,10 @@ react-addons-shallow-compare@^15.6.2:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-dates@18.4.0:
-  version "18.4.0"
-  resolved "https://registry.yarnpkg.com/react-dates/-/react-dates-18.4.0.tgz#c74da8b6f7eb3e70ea640b3a4b0d4f152fc8d602"
-  integrity sha512-EcGS8MH2eclD4838yme4g46e1mjN7Wh4doYJn2aYT6/IKGgz1YOR4Oxd2LlEVH34CfN4DiuqYPjmwPNgvFrKWQ==
+react-dates@18.4.1:
+  version "18.4.1"
+  resolved "https://registry.yarnpkg.com/react-dates/-/react-dates-18.4.1.tgz#82aa0bb4faaa9cdb9547d61c791af2180beda20e"
+  integrity sha512-ew6HiORfbJkEGlJ+5SMC5GtgI87zj2BqNv8tRsdnPtgLMt5fY2Z9dUFxc+XATeRHs+wOm4ku0dlKWpuqBzYapQ==
   dependencies:
     airbnb-prop-types "^2.10.0"
     consolidated-events "^1.1.1 || ^2.0.0"
@@ -3904,15 +3904,15 @@ react-dates@18.4.0:
     react-with-styles "^3.2.0"
     react-with-styles-interface-css "^4.0.2"
 
-react-dom@16.7.0:
-  version "16.7.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.7.0.tgz#a17b2a7ca89ee7390bc1ed5eb81783c7461748b8"
-  integrity sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==
+react-dom@16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0.tgz#5e65527a5e26f22ae3701131bcccaee9fb0d3962"
+  integrity sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.12.0"
+    scheduler "^0.15.0"
 
 react-is@^16.8.1:
   version "16.8.3"
@@ -3975,15 +3975,14 @@ react-with-styles@^3.2.0:
     prop-types "^15.6.1"
     react-with-direction "^1.3.0"
 
-react@16.7.0:
-  version "16.7.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.7.0.tgz#b674ec396b0a5715873b350446f7ea0802ab6381"
-  integrity sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==
+react@16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
+  integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.12.0"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -4301,10 +4300,10 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.12.0.tgz#8ab17699939c0aedc5a196a657743c496538647b"
-  integrity sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==
+scheduler@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
+  integrity sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
bump emblematic-icons to 0.7.1
bump react-dates to 18.4.1
bump react to 16.9.0
bump react-dom to 16.9.0

### how to test
1. checkout branch `chore/bump-react`
2. install dependencies `yarn`
3. crate a link `yarn link`
4. navigate to former-kit and checkout `former-kit` master branch
5. link `former-kit-skin-pagarme` with `former-kit` `yarn link former-kit-skin-pagarme`
6. run `yarn`
7. run storybook `yarn storybook`

related #200 