### PR TITLE
spaced-seg-switch: refactor font-size

### DIFF
--- a/src/styles/segmented-switch/properties.css
+++ b/src/styles/segmented-switch/properties.css
@@ -11,7 +11,7 @@
   --context-switch-letter-spacing: 0.1em;
   --context-switch-text-transform: uppercase;
   --context-switch-font-weight: var(--body-text-weight);
-  --context-switch-font-size: 15px;
+  --context-switch-font-size: 12px;
 
   --context-switch-label-border: 1px solid transparent;
   --context-switch-label-border-radius: 3px;


### PR DESCRIPTION
## Context
This PR changes font-size of spaced segment switch. 

## Checklist
- [x] Change font-size spaced segment switch to 12px.

## Linked Issues
- [x] Resolves https://github.com/pagarme/former-kit-skin-pagarme/issues/197

## Screenshots:
![Captura de tela de 2019-09-26 18-15-53](https://user-images.githubusercontent.com/46823713/65725738-beef3580-e089-11e9-8f74-ed10079162c2.png)

## How to test:
- Generate the link of former-kit-skin-pagarme.
- Link the former-kit-skin-pagarme with the former-kit. Go to former-kit repository and run ``yarn link former-kit-skin-pagarme``.
- Run ``yarn storybook``.
- Go to spacedsegmentedswitch and check if the font-size is 12px.
