### PR TITLE
font: refactor font-weight and add new color

### DIFF
--- a/src/styles/colors/light.css
+++ b/src/styles/colors/light.css
@@ -53,6 +53,7 @@
   --color-light-carbon-60: #2d2d2d;
   --color-light-carbon-50: #2c2c2c;
   --color-light-carbon-40: #383838;
+  --color-light-noir-100: #4d4f62;
 
   --color-light-warning: var(--color-light-orange-100);
   --color-light-error: var(--color-light-red-100);

--- a/src/styles/webfonts/rubik/index.css
+++ b/src/styles/webfonts/rubik/index.css
@@ -1,20 +1,24 @@
+/* stylelint-disable font-weight-notation */
+
 @font-face {
   font-family: "Rubik";
   src: url("./rubik-light.ttf") format("truetype");
-  font-weight: lighter;
+  font-weight: 100 300;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Rubik";
   src: url("./rubik-medium.ttf") format("truetype");
-  font-weight: bold;
+  font-weight: 600 900;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Rubik";
   src: url("./rubik-regular.ttf") format("truetype");
-  font-weight: normal;
+  font-weight: 400 500;
   font-style: normal;
 }
+
+/* stylelint-enable font-weight-notation */


### PR DESCRIPTION
## Context

Font-weight was not being respected through the words ``lighter, normal and bold``.
Changed the values ​​to numeric ranges.

In order to acomplish our new design necessities for `BalanceTotalDisplay` component, we need to add the new color `#4d4f62`.
This PR does that, naming it  `--color-light-noir-100`.

## Linked Issues
- [x] Resolves https://github.com/pagarme/pilot/issues/1310
- [x] Resolves #206

## Checklist
- [x] changed values `lighter, normal and bold` to numeric ranges.
- [x] add color `#4d4f62` as  `--color-light-noir-100`.

