### PR TITLE
modal-actions: refactor margin-left in first-child

### DIFF
--- a/src/styles/modal/index.css
+++ b/src/styles/modal/index.css
@@ -102,7 +102,7 @@
   margin-right: var(--modal-title-icon-spacing);
 }
 
-.actions > * {
+.actions > *:not(:first-child) {
   margin-left: var(--modal-actions-margin);
 }
 


### PR DESCRIPTION
### Context
`ModalActions` component adds margin even on it's first button, a behavior that is unexpected considering the idea is to add space *between* each button. This causes the buttons to not be correctly aligned.
This PR solves that.

### Before
![image](https://user-images.githubusercontent.com/18339615/66228683-70a7eb00-e6b6-11e9-8340-8ed4e282c5a6.png)

### Preview
![Captura de tela de 2019-10-15 11-09-19](https://user-images.githubusercontent.com/46823713/66839373-afeafd00-ef3c-11e9-8efc-88bbd51b3d17.png)

### Requirements
**Checklist**
- [x] Left margin is not added on first child

## Linked Issues
- [x] Resolves https://github.com/pagarme/former-kit/issues/297

## How to test:
- Generate the link of former-kit-skin-pagarme.
- Link the former-kit-skin-pagarme with the former-kit. Go to former-kit repository and run ``yarn link former-kit-skin-pagarme``
- Run ``yarn storybook``
- Go to `Modal/ Default` 
- Open the modal and check if the first button have margin-left.
