### PR TITLE
table: refactor tableEmptyItem style

### DIFF
--- a/src/styles/table/body.css
+++ b/src/styles/table/body.css
@@ -5,10 +5,7 @@
 }
 
 .tableBody .empty {
-  display: block;
-  padding-bottom: var(--table-body-empty-padding-bottom);
   position: relative;
-  width: 100%;
 }
 
 .tableBody .empty:before {


### PR DESCRIPTION
## Context
This PR fixes the alignment from the tableEmptyItem span. Bug found in Pilot's `release/v0.21.0`.

## Checklist
- [ ] Remove padding from tableEmptyItem

## Linked Issues
- [ ] Resolves https://github.com/pagarme/pilot/issues/1484

## How to test?
- Generate an link `former-kit-skin-pagarme`  with `yarn link` and go to `pilot` repository locally and `yarn link former-kit-skin-pagarme`
- See if tableEmptyItem in TransactionsList is with the correct alignment. :tada: 
