### PR TITLE
Legend: add format class

### DIFF
--- a/src/styles/legend/index.css
+++ b/src/styles/legend/index.css
@@ -14,8 +14,15 @@
   box-sizing: border-box;
   padding: var(--legend-label-padding);
   text-align: center;
-  text-transform: uppercase;
   width: auto;
+}
+
+.uppercase {
+  text-transform: uppercase;
+}
+
+.capitalize {
+  text-transform: capitalize;
 }
 
 /* Add type selector to override normalize.css */

--- a/src/styles/legend/properties.css
+++ b/src/styles/legend/properties.css
@@ -4,7 +4,7 @@
 :root {
   --legend-label-border-radius: 3px;
   --legend-label-default-color: var(--color-white);
-  --legend-label-font-size: 10px;
+  --legend-label-font-size: 11px;
   --legend-label-padding: 4px 6px;
   --legend-letter-spacing: var(--letter-spacing);
 


### PR DESCRIPTION
## Context
This PR add `capitalize` and `uppercase` classes to Legend component.

## Checklist
- [x] classes created:
``
{
  text-transform: capitalize;
}
``
``
{
  text-transform: uppercase;
}
``
- [x] change `font-size` to 11px;

## Linked Issues
- [x] Resolves https://github.com/pagarme/former-kit-skin-pagarme/issues/217