### PR TITLE
button: add secondary button variant

### DIFF
--- a/src/styles/button/default/index.css
+++ b/src/styles/button/default/index.css
@@ -1,18 +1,19 @@
 @import "./properties.css";
+@import "../properties.css";
 
 .button {
   align-items: center;
-  border-radius: var(--button-border-radius);
+  border-radius: var(--default-button-border-radius);
   border: none;
   box-sizing: border-box;
   color: var(--button-color);
   cursor: pointer;
   display: inline-flex;
-  font-family: var(--button-font-family);
-  font-style: var(--button-font-style);
-  font-weight: var(--button-font-weight);
+  font-family: var(--default-button-font-family);
+  font-style: var(--default-button-font-style);
+  font-weight: var(--default-button-font-weight);
   justify-content: center;
-  letter-spacing: var(--button-letter-spacing);
+  letter-spacing: var(--default-button-letter-spacing);
   overflow: hidden;
   position: relative;
   transform: translate3d(0, 0, 0);
@@ -156,14 +157,14 @@
   font-size: var(--button-default-font-size);
   height: var(--button-default-height);
   padding: var(--button-default-padding);
-  text-transform: var(--button-default-text-transform);
+  text-transform: var(--default-button-default-text-transform);
 }
 
 .huge {
-  font-size: var(--button-huge-font-size);
-  height: var(--button-huge-height);
+  font-size: var(--default-button-huge-font-size);
+  height: var(--default-button-huge-height);
   padding: var(--button-huge-padding);
-  text-transform: var(--button-huge-text-transform);
+  text-transform: var(--default-button-huge-text-transform);
 
   & > .spinner {
     height: 18px;
@@ -188,11 +189,11 @@
   &.outline {
 
     &:hover {
-      background-color: var(--button-normal-relevance-background-color-hover);
+      background-color: var(--default-button-normal-relevance-background-color-hover);
     }
 
     &:active {
-      background-color: var(--button-normal-relevance-background-color-active);
+      background-color: var(--default-button-normal-relevance-background-color-active);
     }
   }
 
@@ -205,7 +206,7 @@
   }
 
   &.flat {
-    background-color: var(--button-normal-relevance-flat-background-color);
+    background-color: var(--default-button-normal-relevance-flat-background-color);
   }
 
   &.gradient {
@@ -439,7 +440,7 @@
 
   &.button:disabled,
   &.button:disabled:hover {
-    background-color: var(--button-disabled-background-color);
+    background-color: var(--default-button-disabled-background-color);
     background-image: none;
   }
 }
@@ -457,7 +458,7 @@
 
   &.button:disabled,
   &.button:disabled:hover {
-    border-color: var(--button-disabled-background-color);
+    border-color: var(--default-button-disabled-background-color);
   }
 }
 

--- a/src/styles/button/default/properties.css
+++ b/src/styles/button/default/properties.css
@@ -1,0 +1,23 @@
+@import "../../colors.css";
+@import "../../spacing.css";
+@import "../../typography.css";
+
+:root {
+  --default-button-border-radius: 3px;
+  --default-button-font-family: var(--title-font-family);
+  --default-button-font-style: var(--title-font-style);
+  --default-button-font-weight: var(--body-text-weight);
+  --default-button-letter-spacing: var(--letter-spacing);
+
+  --default-button-default-text-transform: uppercase;
+
+  --default-button-huge-font-size: 16px;
+  --default-button-huge-height: 44px;
+  --default-button-huge-text-transform: uppercase;
+
+  --default-button-normal-relevance-background-color-hover: var(--color-light-greenish-120);
+  --default-button-normal-relevance-background-color-active: var(--color-light-greenish-150);
+  --default-button-normal-relevance-flat-background-color: var(--color-light-greenish-100);
+
+  --default-button-disabled-background-color: var(--color-light-silver-50);
+}

--- a/src/styles/button/properties.css
+++ b/src/styles/button/properties.css
@@ -3,23 +3,14 @@
 @import "../typography.css";
 
 :root {
-  --button-border-radius: 3px;
   --button-color: var(--color-white);
-  --button-font-family: var(--title-font-family);
-  --button-font-style: var(--title-font-style);
-  --button-font-weight: var(--body-text-weight);
-  --button-letter-spacing: var(--letter-spacing);
   --button-user-select: none;
 
   --button-default-font-size: 14px;
   --button-default-height: 32px;
   --button-default-padding: 0 var(--spacing-medium);
-  --button-default-text-transform: uppercase;
 
-  --button-huge-font-size: 16px;
-  --button-huge-height: 44px;
   --button-huge-padding: 0 48px;
-  --button-huge-text-transform: uppercase;
 
   --button-tiny-font-size: 12px;
   --button-tiny-height: 26px;
@@ -60,10 +51,7 @@
   --button-low-relevance-clean-color-active: var(--color-light-grey-100);
   --button-low-relevance-clean-color-focus: var(--color-light-iron-100);
 
-  --button-normal-relevance-background-color-hover: var(--color-light-greenish-120);
-  --button-normal-relevance-background-color-active: var(--color-light-greenish-150);
   --button-normal-relevance-boxshadow-focus: var(--color-light-greenish-150) 0 0 0 2px inset;
-  --button-normal-relevance-flat-background-color: var(--color-light-greenish-100);
   --button-normal-relevance-gradient: var(--color-light-greenish-gradient);
   --button-normal-relevance-outline-color: var(--color-light-greenish-100);
   --button-normal-relevance-outline-border-color: var(--color-light-greenish-100);
@@ -77,7 +65,6 @@
   --button-normal-relevance-clean-color-active: var(--color-light-greenish-150);
   --button-normal-relevance-clean-color-focus: var(--color-light-greenish-120);
 
-  --button-disabled-background-color: var(--color-light-silver-50);
   --button-disabled-color: var(--color-light-silver-100);
 
   --button-icon-start-margin:

--- a/src/styles/button/secondary-button/index.css
+++ b/src/styles/button/secondary-button/index.css
@@ -1,0 +1,223 @@
+@import "./properties.css";
+@import "../properties.css";
+
+.button {
+  align-items: center;
+  border-radius: var(--secondary-button-border-radius);
+  border: none;
+  box-sizing: border-box;
+  box-shadow: 3px 3px 15px rgba(0, 0, 0, 0.15);
+  color: var(--button-color);
+  cursor: pointer;
+  display: inline-flex;
+  font-family: var(--secondary-button-font-family);
+  font-weight: var(--secondary-button-font-weight);
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+  transform: translate3d(0, 0, 0);
+  vertical-align: text-top;
+  white-space: nowrap;
+  word-break: keep-all;
+}
+
+.ripple {
+  background-image: var(--button-ripple-background);
+  background-position: center;
+  background-repeat: no-repeat;
+  display: block;
+  height: 100%;
+  left: 0;
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  transform: scale(10);
+  transition: var(--button-ripple-transition);
+  width: 100%;
+}
+
+.spinner {
+  animation: spinner 0.8s linear infinite;
+  border: 1px solid currentColor;
+  border-radius: 100%;
+  border-top-color: transparent;
+  display: inline-flex;
+  height: 14px;
+  transition: all 0.2s;
+  width: 14px;
+
+  &.endAlign {
+    margin-left: 4px;
+  }
+
+  &.startAlign {
+    margin-right: 4px;
+  }
+}
+
+.spinnerOnly {
+  margin-right: 0;
+  position: absolute;
+}
+
+/* This is used to show only the loader spinner when the component is loading */
+
+.hiddenChildren > *:not(.spinner) {
+  visibility: hidden;
+}
+
+.absolute {
+  position: absolute;
+}
+
+.button:active:not(:disabled) .ripple {
+  opacity: var(--button-ripple-active-opacity);
+  transform: scale(0);
+  transition: 0s;
+}
+
+.button:focus {
+  outline: none;
+}
+
+.button::-moz-focus-inner {
+  border: 0;
+}
+
+/* icon alignment */
+
+.button svg {
+
+  &:first-child {
+    margin: var(--button-icon-start-margin);
+  }
+
+  &:last-of-type:not(:first-child) {
+    margin: var(--button-icon-end-margin);
+  }
+}
+
+/* button icon */
+
+.button.iconButton {
+
+  &.tiny,
+  &.default,
+  &.huge {
+    padding: var(--button-icon-padding);
+  }
+
+  &.tiny {
+    width: var(--button-icon-width-tiny);
+  }
+
+  &.default {
+    width: var(--button-icon-width-default);
+  }
+
+  &.huge {
+    width: var(--button-icon-width-huge);
+  }
+
+  & svg {
+    margin: var(--button-only-icon-margin);
+  }
+}
+
+/* button sizes */
+
+.tiny {
+  font-size: var(--button-tiny-font-size);
+  height: var(--button-tiny-height);
+  padding: var(--button-tiny-padding);
+  text-transform: var(--button-tiny-text-transform);
+
+  & > .spinner {
+    height: 12px;
+    width: 12px;
+
+    &.endAlign {
+      margin-left: 6px;
+    }
+
+    &.startAlign {
+      margin-right: 6px;
+    }
+  }
+}
+
+.default {
+  font-size: var(--button-default-font-size);
+  height: var(--button-default-height);
+  padding: var(--button-default-padding);
+  text-transform: var(--secondary-button-default-text-transform);
+}
+
+.huge {
+  font-size: var(--secondary-button-huge-font-size);
+  height: var(--secondary-button-huge-height);
+  padding: var(--button-huge-padding);
+  text-transform: var(--secondary-button-huge-text-transform);
+
+  & > .spinner {
+    height: 18px;
+    width: 18px;
+
+    &.endAlign {
+      margin-left: 6px;
+    }
+
+    &.startAlign {
+      margin-right: 6px;
+    }
+  }
+}
+
+/* button relevances */
+
+.normalRelevance {
+
+  &.flat {
+    background-color: var(--secondary-button-normal-relevance-flat-background-color);
+
+    &:hover {
+      background-color: var(--secondary-button-normal-relevance-background-color-hover);
+    }
+
+    &:active {
+      background-color: var(--secondary-button-normal-relevance-background-color-active);
+    }
+  }
+}
+
+/* disabled button style */
+
+.button,
+.gradient {
+
+  &.button:disabled:hover,
+  &.button:disabled {
+    cursor: not-allowed;
+  }
+}
+
+.flat {
+
+  &.button:disabled,
+  &.button:disabled:hover {
+    background-color: var(--secondary-button-disabled-background-color);
+    background-image: none;
+  }
+}
+
+@keyframes spinner {
+
+  0% {
+    transform: rotate(0);
+  }
+
+  100% {
+    transform: rotate(1turn);
+  }
+}

--- a/src/styles/button/secondary-button/properties.css
+++ b/src/styles/button/secondary-button/properties.css
@@ -1,0 +1,21 @@
+@import "../../spacing.css";
+@import "../../colors.css";
+@import "../../webfonts/roboto/index.css";
+
+:root {
+  --secondary-button-border-radius: 8px;
+  --secondary-button-font-family: "Roboto", sans-serif;
+  --secondary-button-font-weight: 500;
+
+  --secondary-button-default-text-transform: none;
+
+  --secondary-button-huge-font-size: 18px;
+  --secondary-button-huge-height: 64px;
+  --secondary-button-huge-text-transform: none;
+
+  --secondary-button-normal-relevance-background-color-active: var(--color-picklerick-green-200);
+  --secondary-button-normal-relevance-background-color-hover: var(--color-picklerick-green-200);
+  --secondary-button-normal-relevance-flat-background-color: var(--color-picklerick-green-100);
+
+  --secondary-button-disabled-background-color: var(--color-squanchy-gray-200);
+}

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -1,7 +1,7 @@
 const UIAlert = require('./alert/index.css')
 const UIAvatar = require('./avatar/index.css')
 const UIBulletSteps = require('./bullet-steps/index.css')
-const UIButton = require('./button/index.css')
+const UIButton = require('./button/default/index.css')
 const UICard = require('./card/index.css')
 const UICheckbox = require('./checkbox/index.css')
 const UICheckboxForm = require('./checkbox/index.css')
@@ -24,6 +24,7 @@ const UIModal = require('./modal/index.css')
 const UIPagination = require('./pagination/index.css')
 const UIPopover = require('./popover/index.css')
 const UIRadioGroup = require('./radio-group/index.css')
+const UISecondaryButton = require('./button/secondary-button/index.css')
 const UISecondaryLinearProgress = require('./linear-progress/secondary-linear-progress/index.css')
 const UISegmentedSwitch = require('./segmented-switch/index.css')
 const UISidebar = require('./sidebar/index.css')
@@ -65,6 +66,7 @@ module.exports = {
   UIPagination,
   UIPopover,
   UIRadioGroup,
+  UISecondaryButton,
   UISecondaryLinearProgress,
   UISegmentedSwitch,
   UISidebar,


### PR DESCRIPTION
## Context

This PR add the new button variant that is required for the Onboarding history (https://github.com/pagarme/credenciamento/issues/437 and https://github.com/pagarme/pilot/issues/1579).

This PR duplicate a part of the code from `UIButton`, but only the code required for meet the default button props requirements. My idea is that as we are migrating to a new variant, the code is duplicated from the previous version, but only the part of the code that was needed now, and as we need the others features (outline button, circle button, etc), we can implement they. This make senses? :thinking: :smile: 


## Checklist
- [ ] Add SecondaryButton styles

## Linked Issues
- [ ] Issue https://github.com/pagarme/credenciamento/issues/462