### PR TITLE
Adiciona tamanho mobile no componente Modal - skin

### DIFF
--- a/src/styles/modal/index.css
+++ b/src/styles/modal/index.css
@@ -126,10 +126,29 @@
   padding: 0;
 }
 
+.mobile {
+  width: var(--modal-inner-mobile-width);
+  max-width: var(--modal-inner-default-width);
+}
+
 .default {
   width: var(--modal-inner-default-width);
 }
 
 .huge {
   width: var(--modal-inner-huge-width);
+}
+
+.top {
+  align-self: flex-start;
+  margin-top: var(--modal-margin);
+}
+
+.center {
+  align-self: center;
+}
+
+.bottom {
+  align-self: flex-end;
+  margin-bottom: var(--modal-margin);
 }

--- a/src/styles/modal/properties.css
+++ b/src/styles/modal/properties.css
@@ -10,11 +10,12 @@
   --modal-frame-background-color: var(--color-white);
   --modal-frame-border-color: var(--color-light-grey-50);
   --modal-frame-border: solid 1px rgba(var(--modal-frame-border-color), 0.4);
+  --modal-inner-mobile-width: 90vw;
   --modal-inner-default-width: 580px;
   --modal-inner-huge-width: 880px;
   --modal-overlay-background: rgba(var(--color-black), 0.7);
   --modal-padding: var(--spacing-small);
-
+  --modal-margin: var(--spacing-large);
   --modal-child-padding:
     0
     var(--spacing-small)


### PR DESCRIPTION
## Context
Precisamos do modal compativel com tamanho mobile para uso no linkApp.

## Checklist
- [x] Adiciona resolução mobile.
- [x] Adiciona alinhamento vertical

## Linked Issues
- [x] Resolves https://github.com/pagarme/former-kit/issues/324

### Preview:
![image](https://user-images.githubusercontent.com/46823713/75818464-ae00c980-5d77-11ea-9809-9d4051777bdc.png)

### Como testar:
- no `former-kit-skin` entre na branch `add/modal-mobile-size`
- rode `yarn link`
- no `former-kit` entre na branch `add/modal-mobile-size` 
- rode `yarn link "former-kit-skin-pagarme"`
- rode `yarn storybook`
- cheque a historia do Modal com tamanho mobile