### PR TITLE
Ajuste no Dropdown default

### DIFF
--- a/src/styles/dropdown/index.css
+++ b/src/styles/dropdown/index.css
@@ -8,7 +8,6 @@
 .dropdown {
   cursor: pointer;
   position: relative;
-  width: 100%;
 }
 
 .select {


### PR DESCRIPTION
## Context

Este PR remove o `width: 100%` do Dropdown default. Este valor foi adicionado no commit https://github.com/pagarme/former-kit-skin-pagarme/pull/236/commits/648f8c7eed5876f95893b52d5abe094415486a9a, porem, este valor está impactando como este componente se comporta quando há outros componentes próximos.

Desta forma, este PR remove o valor para voltar a configuração antiga.

## Checklist
- [ ] Este PR remove o `width: 100%` do Dropdown default

## Linked Issues
- [ ] Resolves [CRED-25](https://mundipagg.atlassian.net/secure/RapidBoard.jspa?rapidView=186&projectKey=CRED&modal=detail&selectedIssue=CRED-25)
