### PR TITLE
chore: fix LICENSE link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ yarn start
 
 ## Licensing
 
-See [LICENSES](LICENSES.md).
+See [LICENSE](LICENSE.md).
 
 [cssnext]: http://cssnext.io
 [react-scripts]: https://github.com/pagarme/react-scripts-former-kit-dashboard


### PR DESCRIPTION
## Context

The license link was broken in the README.md file.