### PR TITLE
fix: CardActions background color

### DIFF
--- a/src/styles/card/index.css
+++ b/src/styles/card/index.css
@@ -107,7 +107,6 @@
 .actions {
   display: flex;
   justify-content: flex-end;
-  background: var(--color-squanchy-gray-20);
 }
 
 .actions > * {


### PR DESCRIPTION
Removing the gray color in the background.

Before:
![image](https://user-images.githubusercontent.com/3194806/99569208-1ac3fe80-29af-11eb-8003-9c1e758c4990.png)

After:
![image](https://user-images.githubusercontent.com/3194806/99569442-68406b80-29af-11eb-9415-5c9000730962.png)
