### PR TITLE
[EXP-918] Possibilitar scroll interna na modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "former-kit-skin-pagarme",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "A skin for former-kit based on Pagar.me's brand",
   "main": "dist/index.js",
   "repository": "https://github.com/pagarme/former-kit-skin-pagarme.git",

--- a/src/styles/alert/index.css
+++ b/src/styles/alert/index.css
@@ -6,7 +6,7 @@
 }
 
 .alert {
-  align-items: flex-start;
+  align-items: center;
   background-color: transparent;
   border-radius: var(--alert-border-radius);
   box-sizing: border-box;

--- a/src/styles/modal/index.css
+++ b/src/styles/modal/index.css
@@ -13,9 +13,12 @@
   box-shadow: var(--modal-box-shadow);
   height: auto;
   outline: none;
-  overflow: unset;
+  overflow-y: auto;
+  overflow-x: unset;
   position: relative;
   transform: var(--modal-content-transform);
+  max-width: 98%;
+  max-height: 96%;
 
   & .title,
   & .content,


### PR DESCRIPTION
<!-- IMPORTANT: Remove the items which you're not using. -->

## Context
Possibilitar scroll interna na modal e limitar a sua altura para não ocupar toda a tela do usuário. Alinhar os elementos de um alerta no seu centro.

## Checklist
- [x] Adicionar scroll interna na modal
- [x] Limitar altura para não ocupar 100% da tela
- [x] Alinhar elementos do alerta no centro

## Linked Issues
- [[EXP-918] Possibilitar scroll interna na modal](https://mundipagg.atlassian.net/secure/RapidBoard.jspa?rapidView=185&projectKey=EXP&modal=detail&selectedIssue=EXP-918)

## Screenshot
![image](https://user-images.githubusercontent.com/28263075/128879926-ca2a2f50-74e4-4423-8243-27fd5a0c0bbd.png)



[EXP-918]: https://mundipagg.atlassian.net/browse/EXP-918