### PR TITLE
[MCFIN-191][/SEARCH] Ajustar variação de botão do former-kit

### DIFF
--- a/src/styles/button/properties.css
+++ b/src/styles/button/properties.css
@@ -42,21 +42,21 @@
   --button-high-relevance-clean-color-active: var(--color-barney-purple-200);
   --button-high-relevance-clean-color-focus: var(--color-barney-purple-50);
 
-  --button-low-relevance-background-color-hover: var(--color-squanchy-gray-200);
-  --button-low-relevance-background-color-active: var(--color-squanchy-gray-300);
+  --button-low-relevance-background-color-hover: var(--color-squanchy-gray-50);
+  --button-low-relevance-background-color-active: var(--color-squanchy-gray-100);
   --button-low-relevance-boxshadow-focus: #979797 0 0 0 2px inset;
   --button-low-relevance-flat-background-color: var(--color-squanchy-gray-100);
-  --button-low-relevance-outline-color: var(--color-squanchy-gray-100);
+  --button-low-relevance-outline-color: var(--color-birdperson-gray-500);
   --button-low-relevance-outline-border-color: var(--color-squanchy-gray-100);
   --button-low-relevance-outline-border-width: 1px;
   --button-low-relevance-outline-color-enter: var(--color-white);
-  --button-low-relevance-outline-background-color-focus: var(--color-squanchy-gray-100);
+  --button-low-relevance-outline-background-color-focus: var(--color-squanchy-gray-20);
   --button-low-relevance-outline-border-color-focus: #979797;
   --button-low-relevance-outline-boxshadow-focus: #979797 0 0 0 1px inset;
-  --button-low-relevance-clean-color: var(--color-squanchy-gray-100);
-  --button-low-relevance-clean-color-hover: var(--color-squanchy-gray-200);
-  --button-low-relevance-clean-color-active: var(--color-squanchy-gray-300);
-  --button-low-relevance-clean-color-focus: var(--color-squanchy-gray-200);
+  --button-low-relevance-clean-color: var(--color-birdperson-gray-500);
+  --button-low-relevance-clean-color-hover: var(--color-birdperson-gray-600);
+  --button-low-relevance-clean-color-active: var(--color-birdperson-gray-700);
+  --button-low-relevance-clean-color-focus: var(--color-birdperson-gray-600);
 
   --button-normal-relevance-background-color-hover: var(--color-picklerick-green-50);
   --button-normal-relevance-background-color-active: var(--color-picklerick-green-200);


### PR DESCRIPTION
<!-- IMPORTANT: Remove the items which you're not using. -->

## Context
Atualmente possuimos um estilo de botão chamado “Low relevance”, que pode ser consultado [nesse link](https://pagarme.github.io/former-kit/storybook/?path=/story/buttons--default), que por muitas vezes os usuários entendem como um botão desabilitado e, devido a isso, acabam não clicando.

## Checklist
- [x] Alterar a cor de destaque do botão para Neutras/gray-20
- [x] Alterar a cor do texto do botão para Neutras/gray-500
<!-- Describe the main changes that your PR does. -->

## Linked Issues
- [MCFIN-191](https://mundipagg.atlassian.net/browse/MCFIN-191)
<!-- Add the respective issues linked to this PR -->

[MCFIN-191]: https://mundipagg.atlassian.net/browse/MCFIN-191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ